### PR TITLE
Raise the minimum required version of PyDSDL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ package_dir=
     =src
 packages=find:
 install_requires=
-    pydsdl >= 0.5.0
+    pydsdl ~= 1.1
 zip_safe = False
 
 python_requires = >=3.5


### PR DESCRIPTION
This is needed to ensure that the latest patches are pulled in. They are needed for compatibility with https://github.com/UAVCAN/public_regulated_data_types/pull/73