### PR TITLE
[WIP] Another stab at #88

### DIFF
--- a/src/nunavut/jinja/__init__.py
+++ b/src/nunavut/jinja/__init__.py
@@ -375,7 +375,8 @@ class Generator(nunavut.generators.AbstractGenerator):
                                 keep_trailing_newline=True,
                                 lstrip_blocks=lstrip_blocks,
                                 trim_blocks=trim_blocks,
-                                auto_reload=False)
+                                auto_reload=False,
+                                cache_size=0)
 
         self._add_language_support()
 

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 
 __license__ = 'MIT'

--- a/test/gentest_lang/templates/implicit/py/StructureType.j2
+++ b/test/gentest_lang/templates/implicit/py/StructureType.j2
@@ -1,11 +1,28 @@
 
 {% include "id.j2" %}
 
+{# https://github.com/UAVCAN/nunavut/issues/88#issuecomment-546927646 #}
+{% macro generate_unique_items() -%}
+    '{{ 'f'|to_template_unique_name }}',
+    '{{ 'f'|to_template_unique_name }}',
+    '{{ 'f'|to_template_unique_name }}',
+    '{{ 'f'|to_template_unique_name }}',
+{%- endmacro %}
+many_unique_names = [
+    '{{ 'f'|to_template_unique_name }}',
+    '{{ 'f'|to_template_unique_name }}',
+    '{{ 'f'|to_template_unique_name }}',
+    '{{ 'f'|to_template_unique_name }}',
+    {{ generate_unique_items() }}
+    {{ generate_unique_items() }}
+]
+
 lang_py = {
     'unique_name_0': '{{ "NAME" | to_template_unique_name }}',
     'unique_name_1': '{{ "NAME" | to_template_unique_name }}',
     'unique_name_2': '{{ "name" | to_template_unique_name }}',
     'id_0': '{{ "identifier zero" | id }}',
+    'many_unique_names': many_unique_names,
 }
 
 

--- a/test/gentest_lang/test_lang.py
+++ b/test/gentest_lang/test_lang.py
@@ -213,6 +213,11 @@ def ptest_lang_py(gen_paths, implicit):  # type: ignore
     assert "_NAME1_" == lang_py_output["unique_name_1"]
     assert "_name0_" == lang_py_output["unique_name_2"]
     assert "identifier_zero" == lang_py_output["id_0"]
+
+    many_unique_names = lang_py_output.get("many_unique_names")
+    if many_unique_names is not None:
+        assert [('_f%d_' % x) for x in range(12)] == many_unique_names
+
     return generated_values
 
 # +---------------------------------------------------------------------------+


### PR DESCRIPTION
Disabling the Jinja cache results in the unique name generator state disappearing from the global Jinja context:

    >       return _UniqueNameGenerator.ensure_generator_in_globals(env.globals)('c', adj_base_token, '_', '_')
    E       TypeError: 'NoneType' object is not callable
    .tox/py35-test/lib/python3.5/site-packages/nunavut/lang/c.py:527: TypeError

This issue affects all languages. The following test modification indicates that the state gets replaced with None:

    ------------------------- src/nunavut/lang/__init__.py -------------------------
    index bd6524c..135a29a 100644
    @@ -226,7 +226,7 @@ class _UniqueNameGenerator:
        def ensure_generator_in_globals(cls, environment_globals: typing.Dict[str, typing.Any]) -> '_UniqueNameGenerator':
            from .. import TypeLocalGlobalKey

    -        if TypeLocalGlobalKey not in environment_globals:
    +        if environment_globals.get(TypeLocalGlobalKey) is None:
                environment_globals[TypeLocalGlobalKey] = cls()
            return typing.cast('_UniqueNameGenerator', environment_globals[TypeLocalGlobalKey])

I don't quite understand what is happening and why it worked on my machine last week.

@thirtytwobits do you find the added test logic sensible?