### PR TITLE
Fix typo in modules.rst

### DIFF
--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,4 +1,4 @@
-library
+Library
 =======
 
 .. toctree::


### PR DESCRIPTION
This would appear to be my third commit here. All very helpful I'm certain.