### PR TITLE
PyDSDL v1.3+: Support TaggedUnionType

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 license = MIT
 license_file = LICENSE.rst
-keywords = uavcan, dsdl, can, can-bus, codegen, 
+keywords = uavcan, dsdl, can, can-bus, codegen,
 classifiers =
     Development Status :: 3 - Alpha
     Environment :: Console
@@ -35,7 +35,7 @@ package_dir=
     =src
 packages=find:
 install_requires=
-    pydsdl ~= 1.2
+    pydsdl ~= 1.3
     setuptools
 
 zip_safe = False

--- a/src/nunavut/__init__.py
+++ b/src/nunavut/__init__.py
@@ -524,6 +524,8 @@ class DependencyBuilder:
         if isinstance(t, pydsdl.ServiceType):
             return [attr.data_type for attr in t.request_type.attributes] + \
                 [attr.data_type for attr in t.response_type.attributes]
+        elif isinstance(t, pydsdl.TaggedUnionType):
+            return [attr.data_type for attr in t.union_type.attributes]
         else:
             return [attr.data_type for attr in t.attributes]
 

--- a/src/nunavut/lang/py.py
+++ b/src/nunavut/lang/py.py
@@ -319,6 +319,8 @@ def filter_imports(language: Language,
     # Make a list of all attributes defined by this type
     if isinstance(t, pydsdl.ServiceType):
         atr = t.request_type.attributes + t.response_type.attributes
+    elif isinstance(t, pydsdl.TaggedUnionType):
+        atr = t.union_type.attributes
     else:
         atr = t.attributes
 

--- a/src/nunavut/lang/py.py
+++ b/src/nunavut/lang/py.py
@@ -331,8 +331,8 @@ def filter_imports(language: Language,
     dep_types = [x.data_type for x in atr if isinstance(x.data_type, pydsdl.CompositeType)]
     dep_types += [x.data_type.element_type for x in atr if array_w_composite_type(x.data_type)]
 
-    # Make a list of unique full namespaces of referenced composites
-    namespace_list = [x.full_namespace for x in dep_types]
+    # Make a list of unique full namespaces of referenced composites. Use dict instead of set to retain ordering.
+    namespace_list = list({x.full_namespace: None for x in dep_types}.keys())
 
     if language.enable_stropping:
         namespace_list = ['.'.join([filter_id(language, y) for y in x.split('.')]) for x in namespace_list]

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __license__ = 'MIT'


### PR DESCRIPTION
This changeset fixes the dependency list handling which was broken by https://github.com/UAVCAN/pydsdl/pull/34. This functionality was not covered by tests and I left it this way (sorry).

I also fixed the mismatch between the documented behavior and the actual behavior in `py.filter_imports()`: the list should contain unique entries.

The tests fail because the rest of the codebase is not yet updated to use TaggedUnionType. @thirtytwobits what should be done about this?