### PR TITLE
Fix Python dependency imports, fix minor PyDSDL API usage issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 license = MIT
 license_file = LICENSE.rst
-keywords = uavcan, dsdl, can, can-bus, codegen, 
+keywords = uavcan, dsdl, can, can-bus, codegen,
 classifiers =
     Development Status :: 3 - Alpha
     Environment :: Console
@@ -35,7 +35,7 @@ package_dir=
     =src
 packages=find:
 install_requires=
-    pydsdl ~= 1.2
+    pydsdl ~= 1.4
     setuptools
 
 zip_safe = False

--- a/src/nunavut/cli.py
+++ b/src/nunavut/cli.py
@@ -17,7 +17,7 @@ import textwrap
 import typing
 
 
-def _run(args: argparse.Namespace, extra_includes: str) -> int:  # noqa: C901
+def _run(args: argparse.Namespace, extra_includes: typing.List[str]) -> int:  # noqa: C901
     '''
         Post command-line setup and parsing logic to execute nunavut
         library routines based on input.

--- a/src/nunavut/jinja/__init__.py
+++ b/src/nunavut/jinja/__init__.py
@@ -25,7 +25,7 @@ import nunavut.postprocessors
 from nunavut.jinja.jinja2 import (ChoiceLoader, Environment, FileSystemLoader,
                                   PackageLoader, StrictUndefined, Template,
                                   TemplateAssertionError, nodes,
-                                  select_autoescape)
+                                  select_autoescape, FileSystemBytecodeCache)
 from nunavut.jinja.jinja2.ext import Extension
 from nunavut.jinja.jinja2.parser import Parser
 from nunavut.templates import (LANGUAGE_FILTER_ATTRIBUTE_NAME)
@@ -413,7 +413,8 @@ class Generator(nunavut.generators.AbstractGenerator):
                                 lstrip_blocks=lstrip_blocks,
                                 trim_blocks=trim_blocks,
                                 auto_reload=False,
-                                cache_size=0)
+                                cache_size=0,
+                                bytecode_cache=FileSystemBytecodeCache())
 
         self._add_language_support()
 

--- a/src/nunavut/jinja/__init__.py
+++ b/src/nunavut/jinja/__init__.py
@@ -25,7 +25,7 @@ import nunavut.postprocessors
 from nunavut.jinja.jinja2 import (ChoiceLoader, Environment, FileSystemLoader,
                                   PackageLoader, StrictUndefined, Template,
                                   TemplateAssertionError, nodes,
-                                  select_autoescape, FileSystemBytecodeCache)
+                                  select_autoescape)
 from nunavut.jinja.jinja2.ext import Extension
 from nunavut.jinja.jinja2.parser import Parser
 from nunavut.templates import (LANGUAGE_FILTER_ATTRIBUTE_NAME)
@@ -413,8 +413,7 @@ class Generator(nunavut.generators.AbstractGenerator):
                                 lstrip_blocks=lstrip_blocks,
                                 trim_blocks=trim_blocks,
                                 auto_reload=False,
-                                cache_size=0,
-                                bytecode_cache=FileSystemBytecodeCache())
+                                cache_size=0)
 
         self._add_language_support()
 

--- a/src/nunavut/jinja/__init__.py
+++ b/src/nunavut/jinja/__init__.py
@@ -385,7 +385,7 @@ class Generator(nunavut.generators.AbstractGenerator):
 
         self._templates_list = None  # type: typing.Optional[typing.List[pathlib.Path]]
 
-        logger.info("Loading templates from {}".format(templates_dir))
+        logger.info("Loading templates from {}".format(templates_dirs))
 
         fs_loader = FileSystemLoader((str(d) for d in self._templates_dirs), followlinks=followlinks)
 

--- a/src/nunavut/lang/py.py
+++ b/src/nunavut/lang/py.py
@@ -329,8 +329,8 @@ def filter_imports(language: Language,
     dep_types = [x.data_type for x in atr if isinstance(x.data_type, pydsdl.CompositeType)]
     dep_types += [x.data_type.element_type for x in atr if array_w_composite_type(x.data_type)]
 
-    # Make a list of unique full namespaces of referenced composites
-    namespace_list = [x.full_namespace for x in dep_types]
+    # Make a list of unique full namespaces of referenced composites. Use dict instead of set to retain ordering.
+    namespace_list = list({x.full_namespace: None for x in dep_types}.keys())
 
     if language.enable_stropping:
         namespace_list = ['.'.join([filter_id(language, y) for y in x.split('.')]) for x in namespace_list]

--- a/src/nunavut/lang/py.py
+++ b/src/nunavut/lang/py.py
@@ -329,8 +329,12 @@ def filter_imports(language: Language,
     dep_types = [x.data_type for x in atr if isinstance(x.data_type, pydsdl.CompositeType)]
     dep_types += [x.data_type.element_type for x in atr if array_w_composite_type(x.data_type)]
 
-    # Make a list of unique full namespaces of referenced composites. Use dict instead of set to retain ordering.
-    namespace_list = list({x.full_namespace: None for x in dep_types}.keys())
+    # Make a list of unique full namespaces of referenced composites. Keep the original ordering.
+    namespace_list = []
+    for dt in dep_types:
+        ns = dt.full_namespace
+        if ns not in namespace_list:
+            namespace_list.append(ns)
 
     if language.enable_stropping:
         namespace_list = ['.'.join([filter_id(language, y) for y in x.split('.')]) for x in namespace_list]

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -1,8 +1,8 @@
 #
-# Copyright (C) 2018-2019  UAVCAN Development Team  <uavcan.org>
+# Copyright (C) 2018-2020  UAVCAN Development Team  <uavcan.org>
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __license__ = 'MIT'

--- a/test/gentest_any/test_any.py
+++ b/test/gentest_any/test_any.py
@@ -20,7 +20,7 @@ def test_anygen(gen_paths, lang_key):  # type: ignore
     Verifies that any dsdl type will resolve to an ``Any`` template.
     """
     root_namespace_dir = gen_paths.dsdl_dir / Path("uavcan")
-    type_map = read_namespace(str(root_namespace_dir), '')
+    type_map = read_namespace(str(root_namespace_dir), [])
     language_context = LanguageContext(extension='.json')
     namespace = build_namespace_tree(type_map,
                                      root_namespace_dir,

--- a/test/gentest_json/test_json.py
+++ b/test/gentest_json/test_json.py
@@ -22,7 +22,7 @@ def test_TestType_0_1(gen_paths):  # type: ignore
     root_namespace_dir = gen_paths.dsdl_dir / Path("uavcan")
     root_namespace = str(root_namespace_dir)
     language_context = LanguageContext(extension='.json')
-    namespace = build_namespace_tree(read_namespace(root_namespace, ''),
+    namespace = build_namespace_tree(read_namespace(root_namespace, []),
                                      root_namespace_dir,
                                      gen_paths.out_dir,
                                      language_context)

--- a/test/gentest_lang/test_lang.py
+++ b/test/gentest_lang/test_lang.py
@@ -46,7 +46,7 @@ def ptest_lang_c(gen_paths, implicit, unique_name_evaluator):  # type: ignore
     templates_dirs.append(gen_paths.templates_dir / Path("common"))
 
     root_namespace = str(root_namespace_dir)
-    compound_types = read_namespace(root_namespace, '', allow_unregulated_fixed_port_id=True)
+    compound_types = read_namespace(root_namespace, [], allow_unregulated_fixed_port_id=True)
     language_context = LanguageContext('c' if implicit else None, '.h' if not implicit else None)
     namespace = build_namespace_tree(compound_types,
                                      root_namespace_dir,
@@ -111,7 +111,7 @@ def ptest_lang_cpp(gen_paths, implicit):  # type: ignore
 
     root_namespace_dir = gen_paths.dsdl_dir / Path("langtest")
     root_namespace = str(root_namespace_dir)
-    compound_types = read_namespace(root_namespace, '', allow_unregulated_fixed_port_id=True)
+    compound_types = read_namespace(root_namespace, [], allow_unregulated_fixed_port_id=True)
     if implicit:
         templates_dirs = [gen_paths.templates_dir / Path("implicit") / Path("cpp")]
     else:
@@ -179,7 +179,7 @@ def ptest_lang_py(gen_paths, implicit, unique_name_evaluator):  # type: ignore
 
     templates_dirs.append(gen_paths.templates_dir / Path("common"))
 
-    compound_types = read_namespace(root_namespace, '', allow_unregulated_fixed_port_id=True)
+    compound_types = read_namespace(root_namespace, [], allow_unregulated_fixed_port_id=True)
 
     language_context = LanguageContext('py' if implicit else None, '.py' if not implicit else None)
 

--- a/test/gentest_postprocessors/test_postprocessors.py
+++ b/test/gentest_postprocessors/test_postprocessors.py
@@ -21,7 +21,7 @@ from nunavut.lang import LanguageContext
 def _test_common_namespace(gen_paths, target_language: str = 'js', extension: str = '.json'):  # type: ignore
     root_namespace_dir = gen_paths.dsdl_dir / pathlib.Path("uavcan")
     root_namespace = str(root_namespace_dir)
-    return nunavut.build_namespace_tree(pydsdl.read_namespace(root_namespace, ''),
+    return nunavut.build_namespace_tree(pydsdl.read_namespace(root_namespace, []),
                                         root_namespace_dir,
                                         gen_paths.out_dir,
                                         LanguageContext(target_language, extension=extension))

--- a/test/gentest_tests/test_tests.py
+++ b/test/gentest_tests/test_tests.py
@@ -19,7 +19,7 @@ def test_instance_tests(gen_paths):  # type: ignore
     all of its subclasses.
     """
     root_namespace_dir = gen_paths.dsdl_dir / Path("buncho")
-    type_map = read_namespace(str(root_namespace_dir), '')
+    type_map = read_namespace(str(root_namespace_dir), [])
     language_context = LanguageContext('js')
     namespace = build_namespace_tree(type_map,
                                      root_namespace_dir,


### PR DESCRIPTION
Fixes #108 by enabling [bytecode caching](https://jinja.palletsprojects.com/en/2.11.x/api/#bytecode-cache) in Jinja. PyUAVCAN tests pass. Ready to merge if CI is green.

The case described in #108 is down from 55 seconds to 7.7 seconds. Performance profile: [out-bytecode-cache-cumulative.tar.gz](https://github.com/UAVCAN/nunavut/files/4464928/out-bytecode-cache-cumulative.tar.gz)
