### PR TITLE
Fix README example per #118

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Partial example: generating a C struct
             {%- endfor %}
     ...
 
-        } {{ composite_type | full_reference_name }};
+        } {{ T | full_reference_name }};
 
         #endif // {{T.full_name | c.macrofy}}
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist = {py35,py36,py37,py38}-{test,nnvg,doctest},noyaml,lint,mypy,report,docs
 [base]
 deps =
     Sybil
-    pytest
+    pytest >= 5.4.3
     pytest-timeout
     pydsdl
     coverage


### PR DESCRIPTION
Testing:
Test was manual since the README.rst is limited by github's ability to
parse it (i.e. Sybil sections would have been garbage).

  1. Manually copied and pasted template text with change to a folder
`templates`
  2. Using the specification example provided in section 3.8.3.4 invoked
`nnvg -l c my_dsdl_root_namespace/sirius_cyber_corp/ --templates
templates`