### PR TITLE
Inferring target language from extension

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -47,6 +47,7 @@ def run_nnvg(request):  # type: ignore
         return subprocess.run(coverage_args + args,
                               check=check_result,
                               stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE,
                               env=this_env)
     return _run_nnvg
 

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __license__ = 'MIT'


### PR DESCRIPTION
When using nnvg (i.e. this is not an intrinsic feature of the Nunavut
library) the target language can be inferred if only an output extension
is given. This was reported in issue #116.