### PR TITLE
Adding support header templates 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -278,8 +278,8 @@ def jinja_filter_tester(request):  # type: ignore
                                    expected: str,
                                    target_language: typing.Union[typing.Optional[str], LanguageContext],
                                    **globals: typing.Optional[typing.Dict[str, typing.Any]]) -> str:
-        e = Environment(loader=DictLoader({'test': body},),
-                        undefined=StrictUndefined)
+        from nunavut.jinja import CodeGenEnvironment
+        e = CodeGenEnvironment(loader=DictLoader({'test': body}))
 
         if globals is not None:
             e.globals.update(globals)

--- a/conftest.py
+++ b/conftest.py
@@ -248,7 +248,7 @@ def jinja_filter_tester(request):  # type: ignore
 
     Example:
 
-        .. invisible-code-block: python
+        .. code-block: python
 
             from nunavut.templates import template_environment_filter
 
@@ -256,7 +256,6 @@ def jinja_filter_tester(request):  # type: ignore
             def filter_dummy(env, input):
                 return input
 
-        .. code-block:: python
 
             # Given
             I = 'foo'
@@ -267,16 +266,19 @@ def jinja_filter_tester(request):  # type: ignore
             # then
             rendered = I
 
-
-        .. invisible-code-block: python
-
             jinja_filter_tester(filter_dummy, template, rendered, 'c', I=I)
 
+    You can also control the language context:
+
+        .. code-block: python
+            lctx = configurable_language_context_factory({'nunavut.lang.c': {'enable_stropping': False}}, 'c')
+
+            jinja_filter_tester(filter_dummy, template, rendered, lctx, I=I)
     """
     def _make_filter_test_template(filter_or_list: typing.Union[typing.Callable, typing.List[typing.Callable]],
                                    body: str,
                                    expected: str,
-                                   target_language: typing.Union[typing.Optional[str], LanguageContext],
+                                   target_language_or_language_context: typing.Union[typing.Optional[str], LanguageContext],
                                    **globals: typing.Optional[typing.Dict[str, typing.Any]]) -> str:
         from nunavut.jinja import CodeGenEnvironment
         e = CodeGenEnvironment(loader=DictLoader({'test': body}))
@@ -284,10 +286,10 @@ def jinja_filter_tester(request):  # type: ignore
         if globals is not None:
             e.globals.update(globals)
 
-        if isinstance(target_language, LanguageContext):
-            lctx = target_language
+        if isinstance(target_language_or_language_context, LanguageContext):
+            lctx = target_language_or_language_context
         else:
-            lctx = LanguageContext(target_language)
+            lctx = LanguageContext(target_language_or_language_context)
 
         filters = (filter_or_list if isinstance(filter_or_list, list) else [filter_or_list])
         for filter in filters:

--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,7 @@ from sybil.parsers.codeblock import CodeBlockParser
 from sybil.parsers.doctest import DocTestParser
 
 from nunavut import Namespace
-from nunavut.jinja.jinja2 import DictLoader, Environment, StrictUndefined
+from nunavut.jinja.jinja2 import DictLoader
 from nunavut.lang import LanguageContext
 from nunavut.templates import (CONTEXT_FILTER_ATTRIBUTE_NAME,
                                ENVIRONMENT_FILTER_ATTRIBUTE_NAME,

--- a/src/nunavut/__init__.py
+++ b/src/nunavut/__init__.py
@@ -41,7 +41,7 @@ Putting this all together, the typical use of this library looks something like 
     from pydsdl import read_namespace
     from nunavut import build_namespace_tree
     from nunavut.lang import LanguageContext
-    from nunavut.jinja import Generator
+    from nunavut.jinja import DSDLCodeGenerator
 
     # parse the dsdl
     compound_types = read_namespace(root_namespace, include_paths)
@@ -56,7 +56,7 @@ Putting this all together, the typical use of this library looks something like 
                                           language_context)
 
     # give the root namespace to the generator and...
-    generator = Generator(root_namespace)
+    generator = DSDLCodeGeneratorroot_namespace)
 
     # generate all the code!
     generator.generate_all()

--- a/src/nunavut/__init__.py
+++ b/src/nunavut/__init__.py
@@ -56,7 +56,7 @@ Putting this all together, the typical use of this library looks something like 
                                           language_context)
 
     # give the root namespace to the generator and...
-    generator = DSDLCodeGeneratorroot_namespace)
+    generator = DSDLCodeGenerator(root_namespace)
 
     # generate all the code!
     generator.generate_all()

--- a/src/nunavut/cli.py
+++ b/src/nunavut/cli.py
@@ -425,7 +425,7 @@ def _make_parser() -> argparse.ArgumentParser:
     ''').lstrip())
 
     ln_opt_group.add_argument('--target-endianness',
-                              choices=['big', 'little'],
+                              choices=['any', 'big', 'little'],
                               help=textwrap.dedent('''
 
         Specify the endianness of the target hardware. This allows serialization

--- a/src/nunavut/generators.py
+++ b/src/nunavut/generators.py
@@ -245,5 +245,5 @@ def create_generators(namespace: nunavut.Namespace, **kwargs: typing.Any) -> \
     :return: Tuple with the first item being the code-generator and the second the support-library
         generator.
     """
-    from nunavut.jinja import Generator
-    return (Generator(namespace, **kwargs), create_support_generator(namespace))
+    from nunavut.jinja import DSDLCodeGenerator
+    return (DSDLCodeGenerator(namespace, **kwargs), create_support_generator(namespace))

--- a/src/nunavut/generators.py
+++ b/src/nunavut/generators.py
@@ -10,7 +10,6 @@ pydsdl AST into source code.
 """
 
 import abc
-import os
 import pathlib
 import typing
 
@@ -89,152 +88,6 @@ class AbstractGenerator(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
 
-class CopyFromPackageGenerator(AbstractGenerator):
-    """
-    Generates output files by copying them from within the Nunavut package itself.
-    This allows us to embed things in Nunavut that are copied without going through
-    a template engine. This generator always copies files from those returned by
-    the ``file_iterator`` to locations under :func:`nunavut.Namespace.get_support_output_folder()`
-
-    .. invisible-code-block: python
-
-        import pathlib
-        import pytest
-        from unittest.mock import NonCallableMagicMock, MagicMock
-        from nunavut.generators import CopyFromPackageGenerator
-
-        fake_support_output_folder = pathlib.PurePath('tmp')
-
-        namespace = NonCallableMagicMock()
-        namespace.get_support_output_folder = MagicMock(return_value=fake_support_output_folder)
-
-        fake_source_files = [
-            pathlib.Path("foo/bar.a"),
-            pathlib.Path("foo/bar.b")
-        ]
-
-    .. code-block:: python
-
-        def source_file_iterator():
-            # we generate from a list of two fake paths to
-            # demonstrate how the CopyFromPackageGenerator
-            # uses its file_iterator parameter.
-            for source_file in fake_source_files:
-                yield source_file
-
-        generator = CopyFromPackageGenerator(namespace, source_file_iterator(), pathlib.Path('my_subfolder'))
-        assert len(generator.get_templates()) == 2
-        assert len(generator.generate_all(is_dryrun=True)) == 2
-
-        # The generator will copy from the "templates" (i.e. the files within this package to copy) to a
-        # folder under the subfolder provided to its constructor.
-        assert 'my_subfolder' == generator.generate_all(is_dryrun=True)[0].parent.name
-
-        # Note that the sub-folder must be a relative path since the generator will place it under
-        # the path returned by Namespace.get_support_output_folder()
-
-        with pytest.raises(ValueError):
-            _ = CopyFromPackageGenerator(namespace, source_file_iterator(), pathlib.Path('/').resolve())
-
-    .. invisible-code-block: python
-
-        for template in generator.get_templates():
-            print('copy from fake input: ' + str(template))
-
-        for copy_to in generator.generate_all(is_dryrun=True):
-            print('copy to fake output : ' + str(copy_to))
-
-    :param nunavut.Namespace namespace:  The top-level namespace to generates types at and from.
-    :param typing.Generator[pathlib.Path] file_iterator: Provides files within the Nunavut distribution to
-        copy from. All files returned by this iterator will be copied.
-    :param pathlib.Path sub_folders: Folders to create under :func:`nunavut.Namespace.get_support_output_folder()`
-        within which all of the package files will be copied to.
-    """
-
-    def __init__(self,
-                 namespace: nunavut.Namespace,
-                 file_iterator: typing.Generator[pathlib.Path, None, None],
-                 sub_folders: pathlib.Path):
-        super().__init__(namespace)
-        self._file_iterator = file_iterator
-        self._support_resources = None  # type: typing.Optional[typing.Iterable[pathlib.Path]]
-        if sub_folders.is_absolute():
-            raise ValueError('subfolders argument must be a relative path.')
-        self._sub_folders = sub_folders
-
-    def get_templates(self) -> typing.Iterable[pathlib.Path]:
-        files = []
-        resources = self._list_support_resources()
-        for resource in resources:
-            files.append(resource)
-        return files
-
-    def generate_all(self,
-                     is_dryrun: bool = False,
-                     allow_overwrite: bool = True) \
-            -> typing.Iterable[pathlib.Path]:
-
-        target_path = pathlib.Path(self.namespace.get_support_output_folder()) / self._sub_folders
-
-        if not is_dryrun:
-            import shutil
-            os.makedirs(str(target_path), exist_ok=True)
-
-        copied = []  # type: typing.List[pathlib.Path]
-        for resource in self.get_templates():
-            target = target_path / resource.name
-            if not is_dryrun:
-                if not allow_overwrite and target.exists():
-                    raise PermissionError('{} exists. Refusing to overwrite.'.format(str(target)))
-                shutil.copy(str(resource), str(target_path))
-            copied.append(target)
-        return copied
-
-    def _list_support_resources(self) -> typing.Iterable[pathlib.Path]:
-        """
-        Cache all files returned from the file iterator in this object.
-        """
-        if self._support_resources is None:
-            self._support_resources = []
-            for support_file in self._file_iterator:
-                self._support_resources.append(support_file)
-        return self._support_resources
-
-
-def create_support_generator(namespace: nunavut.Namespace, **kwargs: typing.Any) -> 'AbstractGenerator':
-    """
-    Create a new :class:`Generator <nunavut.generators.AbstractGenerator>` that uses embedded support
-    headers, libraries, and other types needed to use generated serialization code for the
-    :func:`target language <nunavut.lang.LanguageContext.get_target_language>`. If no target language
-    is set or if serialization support has been turned off a no-op generator will be returned instead.
-    """
-    class _NoOpSupportGenerator(AbstractGenerator):
-        def get_templates(self) -> typing.Iterable[pathlib.Path]:
-            return []
-
-        def generate_all(self,
-                         is_dryrun: bool = False,
-                         allow_overwrite: bool = True) \
-                -> typing.Iterable[pathlib.Path]:
-            return []
-
-    target_language = namespace.get_language_context().get_target_language()
-
-    if target_language is None or target_language.omit_serialization_support:
-        return _NoOpSupportGenerator(namespace, nunavut.YesNoDefault.DEFAULT)
-    else:
-
-        #  Create the sub-folder to copy-to based on the support namespace.
-        sub_folders = pathlib.Path('')
-
-        for namespace_part in target_language.support_namespace:
-            sub_folders = sub_folders / pathlib.Path(namespace_part)
-
-        return CopyFromPackageGenerator(namespace,
-                                        target_language.support_files,
-                                        sub_folders)
-
-
 def create_generators(namespace: nunavut.Namespace, **kwargs: typing.Any) -> \
         typing.Tuple['AbstractGenerator', 'AbstractGenerator']:
     """
@@ -245,5 +98,5 @@ def create_generators(namespace: nunavut.Namespace, **kwargs: typing.Any) -> \
     :return: Tuple with the first item being the code-generator and the second the support-library
         generator.
     """
-    from nunavut.jinja import DSDLCodeGenerator
-    return (DSDLCodeGenerator(namespace, **kwargs), create_support_generator(namespace))
+    from nunavut.jinja import DSDLCodeGenerator, SupportGenerator
+    return (DSDLCodeGenerator(namespace, **kwargs), SupportGenerator(namespace, **kwargs))

--- a/src/nunavut/generators.py
+++ b/src/nunavut/generators.py
@@ -201,7 +201,7 @@ class CopyFromPackageGenerator(AbstractGenerator):
         return self._support_resources
 
 
-def create_support_generator(namespace: nunavut.Namespace) -> 'AbstractGenerator':
+def create_support_generator(namespace: nunavut.Namespace, **kwargs: typing.Any) -> 'AbstractGenerator':
     """
     Create a new :class:`Generator <nunavut.generators.AbstractGenerator>` that uses embedded support
     headers, libraries, and other types needed to use generated serialization code for the

--- a/src/nunavut/lang/__init__.py
+++ b/src/nunavut/lang/__init__.py
@@ -228,8 +228,8 @@ class Language:
             assert lang_cpp.get_option('target_endianness') == 'little'
 
             # ... or can be provided to a language instance.
-            my_lang = Language('cpp', config, True, language_options={'target_endianness': 'big'})
-            assert my_lang.get_option('target_endianness') == 'big'
+            my_lang = Language('cpp', config, True, language_options={'target_endianness': 'any'})
+            assert my_lang.get_option('target_endianness') == 'any'
 
             # Also, this method can provide a sane default.
             assert lang_cpp.get_option('foobar', 'sane_default') == 'sane_default'

--- a/src/nunavut/lang/_common.py
+++ b/src/nunavut/lang/_common.py
@@ -39,7 +39,8 @@ class IncludeGenerator(DependencyBuilder):
             namespace_path = pathlib.Path('')
             for namespace_part in self._language.support_namespace:
                 namespace_path = namespace_path / pathlib.Path(namespace_part)
-            path_list += [str(namespace_path / pathlib.Path(p.name)) for p in self._language.support_files]
+            path_list += [str(namespace_path / pathlib.Path(p.name).with_suffix(output_extension))
+                          for p in self._language.support_files]
 
         prefer_system_includes = bool(self._language.get_config_value_as_bool('prefer_system_includes', False))
         if prefer_system_includes:

--- a/src/nunavut/lang/c/__init__.py
+++ b/src/nunavut/lang/c/__init__.py
@@ -222,7 +222,8 @@ def filter_macrofy(language: Language, value: str) -> str:
 
         # ...but it will not be stropped within the macro.
         rendered = '''#ifndef NAMESPACED_TYPE_REGISTER
-        _register'''
+        _register
+        '''
 
     .. invisible-code-block: python
 

--- a/src/nunavut/lang/c/__init__.py
+++ b/src/nunavut/lang/c/__init__.py
@@ -309,7 +309,7 @@ class _CFit(enum.Enum):
                   language: Language,
                   inttype_prefix: typing.Optional[str] = None) -> str:
         use_standard_types = language.get_config_value_as_bool('use_standard_types')
-        safe_prefix = '' if inttype_prefix is None else inttype_prefix
+        safe_prefix = '' if not use_standard_types or inttype_prefix is None else inttype_prefix
         if isinstance(value, pydsdl.UnsignedIntegerType):
             return safe_prefix + (self.to_c_int(False) if not use_standard_types else self.to_std_int(False))
         elif isinstance(value, pydsdl.SignedIntegerType):

--- a/src/nunavut/lang/c/support/__init__.py
+++ b/src/nunavut/lang/c/support/__init__.py
@@ -29,7 +29,7 @@ def list_support_files() -> typing.Generator[pathlib.Path, None, None]:
         for path in list_support_files():
             support_file_count += 1
             assert path.parent.stem == 'support'
-            assert path.suffix == '.h'
+            assert (path.suffix == '.h' or path.suffix == '.j2')
 
     .. invisible-code-block: python
 
@@ -38,5 +38,5 @@ def list_support_files() -> typing.Generator[pathlib.Path, None, None]:
     :return: A list of C support header resources.
     """
     for resource in pkg_resources.resource_listdir(__name__, '.'):
-        if resource.endswith('.h'):
+        if resource.endswith('.h') or resource.endswith('.j2'):
             yield pathlib.Path(pkg_resources.resource_filename(__name__, str(resource)))

--- a/src/nunavut/lang/cpp/__init__.py
+++ b/src/nunavut/lang/cpp/__init__.py
@@ -10,7 +10,6 @@
 
 import functools
 import io
-import math
 import re
 import typing
 

--- a/src/nunavut/lang/cpp/support/__init__.py
+++ b/src/nunavut/lang/cpp/support/__init__.py
@@ -39,5 +39,5 @@ def list_support_files() -> typing.Generator[pathlib.Path, None, None]:
     :return: A list of C++ support header resources.
     """
     for resource in pkg_resources.resource_listdir(__name__, '.'):
-        if resource.endswith('.hpp'):
+        if resource.endswith('.hpp') or resource.endswith('.j2'):
             yield pathlib.Path(pkg_resources.resource_filename(__name__, str(resource)))

--- a/src/nunavut/lang/cpp/support/__init__.py
+++ b/src/nunavut/lang/cpp/support/__init__.py
@@ -30,7 +30,7 @@ def list_support_files() -> typing.Generator[pathlib.Path, None, None]:
         for path in list_support_files():
             support_file_count += 1
             assert path.parent.stem == 'support'
-            assert path.suffix == '.hpp'
+            assert (path.suffix == '.hpp' or path.suffix == '.j2')
 
     .. invisible-code-block: python
 

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -14,7 +14,7 @@ namespace nunavut
 {
 namespace support
 {
-
+// Target Endianess: {{ option_target_endianness }}
 // TODO: create C++ support header
 
 }  // namespace support

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 __license__ = 'MIT'

--- a/test/gentest_any/test_any.py
+++ b/test/gentest_any/test_any.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from pydsdl import read_namespace
 from nunavut import build_namespace_tree
-from nunavut.jinja import Generator
+from nunavut.jinja import DSDLCodeGenerator
 from nunavut.lang import LanguageContext
 
 import pytest
@@ -26,7 +26,7 @@ def test_anygen(gen_paths, lang_key):  # type: ignore
                                      root_namespace_dir,
                                      str(gen_paths.out_dir),
                                      language_context)
-    generator = Generator(namespace, templates_dir=gen_paths.templates_dir)
+    generator = DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir)
     generator.generate_all(False)
 
     outfile = gen_paths.find_outfile_in_namespace("uavcan.time.SynchronizedTimestamp", namespace)

--- a/test/gentest_filters/test_filters.py
+++ b/test/gentest_filters/test_filters.py
@@ -75,9 +75,9 @@ def test_custom_filter_and_test(gen_paths):  # type: ignore
                                      language_context)
     template_path = gen_paths.templates_dir / Path('custom_filter_and_test')
     generator = DSDLCodeGenerator(namespace,
-                          templates_dir=template_path,
-                          additional_filters={'custom_filter': lambda T: 'hi mum'},
-                          additional_tests={'custom_test': lambda T: True})
+                                  templates_dir=template_path,
+                                  additional_filters={'custom_filter': lambda T: 'hi mum'},
+                                  additional_tests={'custom_test': lambda T: True})
 
     generator.generate_all()
     outfile = gen_paths.find_outfile_in_namespace("uavcan.time.SynchronizedTimestamp", namespace)
@@ -98,13 +98,13 @@ def test_custom_filter_and_test_redefinition(gen_paths):  # type: ignore
 
     with pytest.raises(RuntimeError):
         DSDLCodeGenerator(namespace,
-                  additional_filters={'type_to_include_path': lambda T: ''},
-                  additional_tests={'custom_test': lambda T: False})
+                          additional_filters={'type_to_include_path': lambda T: ''},
+                          additional_tests={'custom_test': lambda T: False})
 
     with pytest.raises(RuntimeError):
         DSDLCodeGenerator(namespace,
-                  additional_filters={'custom_filter': lambda T: ''},
-                  additional_tests={'primitive': lambda T: False})
+                          additional_filters={'custom_filter': lambda T: ''},
+                          additional_tests={'primitive': lambda T: False})
 
 
 def test_python_filter_full_reference_name(gen_paths):  # type: ignore

--- a/test/gentest_filters/test_filters.py
+++ b/test/gentest_filters/test_filters.py
@@ -12,7 +12,7 @@ import pytest
 from pydsdl import read_namespace
 
 from nunavut import Namespace, build_namespace_tree
-from nunavut.jinja import Generator
+from nunavut.jinja import DSDLCodeGenerator
 from nunavut.jinja.jinja2.exceptions import TemplateAssertionError
 from nunavut.lang import LanguageContext
 
@@ -30,7 +30,7 @@ def test_template_assert(gen_paths):  # type: ignore
                                      output_path,
                                      language_context)
     template_path = gen_paths.templates_dir / Path('assert')
-    generator = Generator(namespace, templates_dir=template_path)
+    generator = DSDLCodeGenerator(namespace, templates_dir=template_path)
     try:
         generator.generate_all()
         assert False
@@ -51,7 +51,7 @@ def test_type_to_include(gen_paths):  # type: ignore
                                      output_path,
                                      language_context)
     template_path = gen_paths.templates_dir / Path('type_to_include')
-    generator = Generator(namespace, templates_dir=template_path)
+    generator = DSDLCodeGenerator(namespace, templates_dir=template_path)
     generator.generate_all()
     outfile = gen_paths.find_outfile_in_namespace("uavcan.time.SynchronizedTimestamp", namespace)
 
@@ -74,7 +74,7 @@ def test_custom_filter_and_test(gen_paths):  # type: ignore
                                      output_path,
                                      language_context)
     template_path = gen_paths.templates_dir / Path('custom_filter_and_test')
-    generator = Generator(namespace,
+    generator = DSDLCodeGenerator(namespace,
                           templates_dir=template_path,
                           additional_filters={'custom_filter': lambda T: 'hi mum'},
                           additional_tests={'custom_test': lambda T: True})
@@ -97,12 +97,12 @@ def test_custom_filter_and_test_redefinition(gen_paths):  # type: ignore
     namespace = Namespace('', Path(), PurePath(), language_context)
 
     with pytest.raises(RuntimeError):
-        Generator(namespace,
+        DSDLCodeGenerator(namespace,
                   additional_filters={'type_to_include_path': lambda T: ''},
                   additional_tests={'custom_test': lambda T: False})
 
     with pytest.raises(RuntimeError):
-        Generator(namespace,
+        DSDLCodeGenerator(namespace,
                   additional_filters={'custom_filter': lambda T: ''},
                   additional_tests={'primitive': lambda T: False})
 

--- a/test/gentest_json/test_json.py
+++ b/test/gentest_json/test_json.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from pydsdl import read_namespace
 from nunavut import build_namespace_tree
 from nunavut.lang import LanguageContext
-from nunavut.jinja import Generator
+from nunavut.jinja import DSDLCodeGenerator
 
 
 def test_TestType_0_1(gen_paths):  # type: ignore
@@ -26,7 +26,7 @@ def test_TestType_0_1(gen_paths):  # type: ignore
                                      root_namespace_dir,
                                      gen_paths.out_dir,
                                      language_context)
-    generator = Generator(namespace, templates_dir=gen_paths.templates_dir)
+    generator = DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir)
     generator.generate_all(False)
 
     # Now read back in and verify

--- a/test/gentest_lang/test_lang.py
+++ b/test/gentest_lang/test_lang.py
@@ -61,7 +61,7 @@ def ptest_lang_c(gen_paths: Any,
                                      gen_paths.out_dir,
                                      language_context)
     generator = DSDLCodeGenerator(namespace,
-                          templates_dir=templates_dirs)
+                                  templates_dir=templates_dirs)
     generator.generate_all(False)
 
     # Now read back in and verify
@@ -135,7 +135,7 @@ def ptest_lang_cpp(gen_paths, implicit):  # type: ignore
                                      language_context)
 
     generator = DSDLCodeGenerator(namespace,
-                          templates_dir=templates_dirs)
+                                  templates_dir=templates_dirs)
 
     generator.generate_all(False)
 
@@ -196,8 +196,8 @@ def ptest_lang_py(gen_paths, implicit, unique_name_evaluator):  # type: ignore
                                      gen_paths.out_dir,
                                      language_context)
     generator = DSDLCodeGenerator(namespace,
-                          generate_namespace_types=YesNoDefault.NO,
-                          templates_dir=templates_dirs)
+                                  generate_namespace_types=YesNoDefault.NO,
+                                  templates_dir=templates_dirs)
 
     generator.generate_all(False)
 

--- a/test/gentest_lang/test_lang.py
+++ b/test/gentest_lang/test_lang.py
@@ -12,7 +12,7 @@ import pytest
 from pydsdl import read_namespace
 
 from nunavut import YesNoDefault, build_namespace_tree
-from nunavut.jinja import Generator
+from nunavut.jinja import DSDLCodeGenerator
 from nunavut.lang import Language, LanguageContext
 from nunavut.lang.c import filter_id as c_filter_id
 from nunavut.lang.cpp import filter_id as cpp_filter_id
@@ -60,7 +60,7 @@ def ptest_lang_c(gen_paths: Any,
                                      root_namespace_dir,
                                      gen_paths.out_dir,
                                      language_context)
-    generator = Generator(namespace,
+    generator = DSDLCodeGenerator(namespace,
                           templates_dir=templates_dirs)
     generator.generate_all(False)
 
@@ -134,7 +134,7 @@ def ptest_lang_cpp(gen_paths, implicit):  # type: ignore
                                      gen_paths.out_dir,
                                      language_context)
 
-    generator = Generator(namespace,
+    generator = DSDLCodeGenerator(namespace,
                           templates_dir=templates_dirs)
 
     generator.generate_all(False)
@@ -195,7 +195,7 @@ def ptest_lang_py(gen_paths, implicit, unique_name_evaluator):  # type: ignore
                                      root_namespace_dir,
                                      gen_paths.out_dir,
                                      language_context)
-    generator = Generator(namespace,
+    generator = DSDLCodeGenerator(namespace,
                           generate_namespace_types=YesNoDefault.NO,
                           templates_dir=templates_dirs)
 

--- a/test/gentest_lookup/test_lookup.py
+++ b/test/gentest_lookup/test_lookup.py
@@ -11,7 +11,7 @@ import json
 from pydsdl import read_namespace
 from nunavut import build_namespace_tree, Namespace
 from nunavut.lang import LanguageContext
-from nunavut.jinja import Generator
+from nunavut.jinja import DSDLCodeGenerator
 
 
 class a:
@@ -39,10 +39,10 @@ def test_bfs_of_type_for_template(gen_paths):  # type: ignore
                                 gen_paths.dsdl_dir,
                                 gen_paths.out_dir,
                                 language_context)
-    generator = Generator(empty_namespace, templates_dir=gen_paths.templates_dir)
+    generator = DSDLCodeGenerator(empty_namespace, templates_dir=gen_paths.templates_dir)
     subject = d()
     template_file = generator.filter_type_to_template(subject)
-    assert str(Path('c').with_suffix(Generator.TEMPLATE_SUFFIX)) == template_file
+    assert str(Path('c').with_suffix(DSDLCodeGenerator.TEMPLATE_SUFFIX)) == template_file
     assert generator.filter_type_to_template(subject) == template_file
 
 
@@ -58,7 +58,7 @@ def test_one_template(gen_paths):  # type: ignore
                                      root_namespace_dir,
                                      gen_paths.out_dir,
                                      language_context)
-    generator = Generator(namespace, templates_dir=gen_paths.templates_dir)
+    generator = DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir)
     generator.generate_all(False)
 
     outfile = gen_paths.find_outfile_in_namespace("uavcan.time.TimeSystem", namespace)
@@ -73,7 +73,7 @@ def test_one_template(gen_paths):  # type: ignore
 
 def test_get_templates(gen_paths):  # type: ignore
     """
-    Verifies the nunavut.jinja.Generator.get_templates() method.
+    Verifies the nunavut.jinja.DSDLCodeGenerator.get_templates() method.
     """
     root_namespace_dir = gen_paths.dsdl_dir / Path("uavcan")
     root_namespace = str(root_namespace_dir)
@@ -83,7 +83,7 @@ def test_get_templates(gen_paths):  # type: ignore
                                      root_namespace_dir,
                                      gen_paths.out_dir,
                                      language_context)
-    generator = Generator(namespace, templates_dir=gen_paths.templates_dir)
+    generator = DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir)
 
     templates = generator.get_templates()
 

--- a/test/gentest_multiple/test_multiple.py
+++ b/test/gentest_multiple/test_multiple.py
@@ -11,7 +11,7 @@ import pytest
 from pydsdl import FrontendError, read_namespace
 
 from nunavut import build_namespace_tree
-from nunavut.jinja import Generator
+from nunavut.jinja import DSDLCodeGenerator
 from nunavut.lang import LanguageContext
 
 
@@ -36,7 +36,7 @@ def test_three_roots(gen_paths):  # type: ignore
                                      root_namespace,
                                      gen_paths.out_dir,
                                      language_context)
-    generator = Generator(namespace, templates_dir=gen_paths.templates_dir)
+    generator = DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir)
     generator.generate_all(False)
 
     # Now read back in and verify

--- a/test/gentest_namespaces/test_namespaces.py
+++ b/test/gentest_namespaces/test_namespaces.py
@@ -12,7 +12,7 @@ import pytest
 from pydsdl import Any, CompositeType, read_namespace
 
 from nunavut import Namespace, build_namespace_tree, YesNoDefault
-from nunavut.jinja import Generator
+from nunavut.jinja import DSDLCodeGenerator
 from nunavut.lang import LanguageContext
 
 
@@ -106,7 +106,7 @@ def test_empty_namespace(gen_paths):  # type: ignore
 def parameterized_test_namespace_(gen_paths, templates_subdir):  # type: ignore
     language_context = LanguageContext(extension='.json')
     namespace, root_namespace_path, _ = gen_test_namespace(gen_paths, language_context)
-    generator = Generator(namespace, YesNoDefault.NO,
+    generator = DSDLCodeGenerator(namespace, YesNoDefault.NO,
                           templates_dir=gen_paths.templates_dir / Path(templates_subdir))
     generator.generate_all()
     assert namespace.source_file_path == root_namespace_path
@@ -131,7 +131,7 @@ def test_namespace_generation(gen_paths):  # type: ignore
     language_context = LanguageContext(extension='.json', namespace_output_stem='__module__')
     namespace, root_namespace_path, compound_types = gen_test_namespace(gen_paths, language_context)
     assert len(compound_types) == 2
-    generator = Generator(namespace, YesNoDefault.YES,
+    generator = DSDLCodeGenerator(namespace, YesNoDefault.YES,
                           templates_dir=gen_paths.templates_dir / Path('default'))
     generator.generate_all()
     for nested_namespace in namespace.get_nested_namespaces():
@@ -169,7 +169,7 @@ def test_namespace_stropping(gen_paths,
     language_context = LanguageContext(language_key)
     namespace, root_namespace_path, compound_types = gen_test_namespace(gen_paths, language_context)
     assert len(compound_types) == 2
-    generator = Generator(namespace, YesNoDefault.YES,
+    generator = DSDLCodeGenerator(namespace, YesNoDefault.YES,
                           templates_dir=gen_paths.templates_dir / Path('default'))
     generator.generate_all()
 

--- a/test/gentest_namespaces/test_namespaces.py
+++ b/test/gentest_namespaces/test_namespaces.py
@@ -106,8 +106,9 @@ def test_empty_namespace(gen_paths):  # type: ignore
 def parameterized_test_namespace_(gen_paths, templates_subdir):  # type: ignore
     language_context = LanguageContext(extension='.json')
     namespace, root_namespace_path, _ = gen_test_namespace(gen_paths, language_context)
-    generator = DSDLCodeGenerator(namespace, YesNoDefault.NO,
-                          templates_dir=gen_paths.templates_dir / Path(templates_subdir))
+    generator = DSDLCodeGenerator(namespace,
+                                  generate_namespace_types=YesNoDefault.NO,
+                                  templates_dir=gen_paths.templates_dir / Path(templates_subdir))
     generator.generate_all()
     assert namespace.source_file_path == root_namespace_path
     assert namespace.full_name == 'scotec'
@@ -131,8 +132,9 @@ def test_namespace_generation(gen_paths):  # type: ignore
     language_context = LanguageContext(extension='.json', namespace_output_stem='__module__')
     namespace, root_namespace_path, compound_types = gen_test_namespace(gen_paths, language_context)
     assert len(compound_types) == 2
-    generator = DSDLCodeGenerator(namespace, YesNoDefault.YES,
-                          templates_dir=gen_paths.templates_dir / Path('default'))
+    generator = DSDLCodeGenerator(namespace,
+                                  generate_namespace_types=YesNoDefault.YES,
+                                  templates_dir=gen_paths.templates_dir / Path('default'))
     generator.generate_all()
     for nested_namespace in namespace.get_nested_namespaces():
         nested_namespace_path = Path(root_namespace_path) / Path(*nested_namespace.full_name.split('.')[1:])
@@ -169,8 +171,9 @@ def test_namespace_stropping(gen_paths,
     language_context = LanguageContext(language_key)
     namespace, root_namespace_path, compound_types = gen_test_namespace(gen_paths, language_context)
     assert len(compound_types) == 2
-    generator = DSDLCodeGenerator(namespace, YesNoDefault.YES,
-                          templates_dir=gen_paths.templates_dir / Path('default'))
+    generator = DSDLCodeGenerator(namespace,
+                                  generate_namespace_types=YesNoDefault.YES,
+                                  templates_dir=gen_paths.templates_dir / Path('default'))
     generator.generate_all()
 
     expected_stropped_ns = 'scotec.{}.{}'.format(expected_stropp_part_0, expected_stropp_part_1)

--- a/test/gentest_postprocessors/test_postprocessors.py
+++ b/test/gentest_postprocessors/test_postprocessors.py
@@ -65,7 +65,7 @@ def test_unknown_intermediate(gen_paths):  # type: ignore
             return generated
 
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[InvalidType()])
     with pytest.raises(ValueError):
@@ -76,7 +76,7 @@ def test_empty_pp_array(gen_paths):  # type: ignore
     """ Verifies the behavior of a zero length post_processors argument.
     """
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[])
     generator.generate_all(False, True)
@@ -88,7 +88,7 @@ def test_chmod(gen_paths):  # type: ignore
     """ Generates a file using a SetFileMode post-processor.
     """
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
     generator.generate_all(False, True)
@@ -102,7 +102,7 @@ def test_overwrite(gen_paths):  # type: ignore
     """ Verifies the allow_overwrite flag contracts.
     """
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
     generator.generate_all(False, True)
@@ -119,7 +119,7 @@ def test_overwrite_dryrun(gen_paths):  # type: ignore
     """ Verifies the allow_overwrite flag contracts.
     """
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
     generator.generate_all(False, True)
@@ -196,7 +196,7 @@ def test_move_file(gen_paths):  # type: ignore
     verifier = Verifier()
 
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[mover, verifier])
     generator.generate_all(False, True)
@@ -230,7 +230,7 @@ def test_line_pp(gen_paths):  # type: ignore
     line_pp0 = TestLinePostProcessor0()
     line_pp1 = TestLinePostProcessor1()
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[line_pp0, line_pp1])
     generator.generate_all(False, True)
@@ -245,7 +245,7 @@ def test_line_pp_returns_none(gen_paths):  # type: ignore
             return None  # type: ignore
 
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[TestBadLinePostProcessor()])
     with pytest.raises(ValueError):
@@ -254,7 +254,7 @@ def test_line_pp_returns_none(gen_paths):  # type: ignore
 
 def test_trim_trailing_ws(gen_paths):  # type: ignore
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[nunavut.postprocessors.TrimTrailingWhitespace()])
     generator.generate_all(False, True)
@@ -267,7 +267,7 @@ def test_trim_trailing_ws(gen_paths):  # type: ignore
 
 def test_limit_empty_lines(gen_paths):  # type: ignore
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[nunavut.postprocessors.LimitEmptyLines(0)])
     generator.generate_all(False, True)
@@ -371,7 +371,7 @@ def test_external_edit_in_place(gen_paths):  # type: ignore
     namespace = _test_common_namespace(gen_paths)
     ext_program = gen_paths.test_dir / pathlib.Path('ext_program.py')
     edit_in_place = nunavut.postprocessors.ExternalProgramEditInPlace([str(ext_program)])
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[edit_in_place])
     generator.generate_all(False, True)
@@ -394,13 +394,13 @@ def test_external_edit_in_place_fail(gen_paths):  # type: ignore
     ext_program = gen_paths.test_dir / pathlib.Path('ext_program.py')
     simulated_error_args = [str(ext_program), '--simulate-error']
     edit_in_place_checking = nunavut.postprocessors.ExternalProgramEditInPlace(simulated_error_args)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[edit_in_place_checking])
     with pytest.raises(subprocess.CalledProcessError):
         generator.generate_all(False, True)
     edit_in_place_not_checking = nunavut.postprocessors.ExternalProgramEditInPlace(simulated_error_args, check=False)
-    generator = nunavut.jinja.Generator(namespace,
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
                                         templates_dir=gen_paths.templates_dir,
                                         post_processors=[edit_in_place_not_checking])
     generator.generate_all(False, True)

--- a/test/gentest_postprocessors/test_postprocessors.py
+++ b/test/gentest_postprocessors/test_postprocessors.py
@@ -66,8 +66,8 @@ def test_unknown_intermediate(gen_paths):  # type: ignore
 
     namespace = _test_common_namespace(gen_paths)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[InvalidType()])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[InvalidType()])
     with pytest.raises(ValueError):
         generator.generate_all(False, True)
 
@@ -77,8 +77,8 @@ def test_empty_pp_array(gen_paths):  # type: ignore
     """
     namespace = _test_common_namespace(gen_paths)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[])
     generator.generate_all(False, True)
 
     _test_common_post_condition(gen_paths, namespace)
@@ -89,8 +89,8 @@ def test_chmod(gen_paths):  # type: ignore
     """
     namespace = _test_common_namespace(gen_paths)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
     generator.generate_all(False, True)
 
     outfile = _test_common_post_condition(gen_paths, namespace)
@@ -103,8 +103,8 @@ def test_overwrite(gen_paths):  # type: ignore
     """
     namespace = _test_common_namespace(gen_paths)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
     generator.generate_all(False, True)
 
     with pytest.raises(PermissionError):
@@ -120,8 +120,8 @@ def test_overwrite_dryrun(gen_paths):  # type: ignore
     """
     namespace = _test_common_namespace(gen_paths)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
     generator.generate_all(False, True)
 
     with pytest.raises(PermissionError):
@@ -197,8 +197,8 @@ def test_move_file(gen_paths):  # type: ignore
 
     namespace = _test_common_namespace(gen_paths)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[mover, verifier])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[mover, verifier])
     generator.generate_all(False, True)
 
     assert mover.called
@@ -231,8 +231,8 @@ def test_line_pp(gen_paths):  # type: ignore
     line_pp1 = TestLinePostProcessor1()
     namespace = _test_common_namespace(gen_paths)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[line_pp0, line_pp1])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[line_pp0, line_pp1])
     generator.generate_all(False, True)
     assert len(line_pp1._lines) > 0
     _test_common_post_condition(gen_paths, namespace)
@@ -246,8 +246,8 @@ def test_line_pp_returns_none(gen_paths):  # type: ignore
 
     namespace = _test_common_namespace(gen_paths)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[TestBadLinePostProcessor()])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[TestBadLinePostProcessor()])
     with pytest.raises(ValueError):
         generator.generate_all(False, True)
 
@@ -255,8 +255,8 @@ def test_line_pp_returns_none(gen_paths):  # type: ignore
 def test_trim_trailing_ws(gen_paths):  # type: ignore
     namespace = _test_common_namespace(gen_paths)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[nunavut.postprocessors.TrimTrailingWhitespace()])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[nunavut.postprocessors.TrimTrailingWhitespace()])
     generator.generate_all(False, True)
     outfile = _test_common_post_condition(gen_paths, namespace)
 
@@ -268,8 +268,8 @@ def test_trim_trailing_ws(gen_paths):  # type: ignore
 def test_limit_empty_lines(gen_paths):  # type: ignore
     namespace = _test_common_namespace(gen_paths)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[nunavut.postprocessors.LimitEmptyLines(0)])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[nunavut.postprocessors.LimitEmptyLines(0)])
     generator.generate_all(False, True)
     outfile = _test_common_post_condition(gen_paths, namespace)
 
@@ -372,8 +372,8 @@ def test_external_edit_in_place(gen_paths):  # type: ignore
     ext_program = gen_paths.test_dir / pathlib.Path('ext_program.py')
     edit_in_place = nunavut.postprocessors.ExternalProgramEditInPlace([str(ext_program)])
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[edit_in_place])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[edit_in_place])
     generator.generate_all(False, True)
 
     outfile = gen_paths.find_outfile_in_namespace("uavcan.test.TestType", namespace)
@@ -395,14 +395,14 @@ def test_external_edit_in_place_fail(gen_paths):  # type: ignore
     simulated_error_args = [str(ext_program), '--simulate-error']
     edit_in_place_checking = nunavut.postprocessors.ExternalProgramEditInPlace(simulated_error_args)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[edit_in_place_checking])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[edit_in_place_checking])
     with pytest.raises(subprocess.CalledProcessError):
         generator.generate_all(False, True)
     edit_in_place_not_checking = nunavut.postprocessors.ExternalProgramEditInPlace(simulated_error_args, check=False)
     generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                        templates_dir=gen_paths.templates_dir,
-                                        post_processors=[edit_in_place_not_checking])
+                                                templates_dir=gen_paths.templates_dir,
+                                                post_processors=[edit_in_place_not_checking])
     generator.generate_all(False, True)
 
 

--- a/test/gentest_serialization/test_serialization.py
+++ b/test/gentest_serialization/test_serialization.py
@@ -9,17 +9,26 @@ Test the generation of serialization support generically and for python.
 from pathlib import Path
 
 from nunavut import generate_types
+from nunavut.lang import LanguageContext
 import pytest
 
 
-@pytest.mark.parametrize('lang_key', ['cpp'])
-def test_hello_serialization(gen_paths, lang_key):  # type: ignore
+@pytest.mark.parametrize('lang_key', ['cpp', 'c'])
+def test_support_headers(gen_paths, lang_key):  # type: ignore
     """
-    don't know yet
+    Test that the support headers are generated/copied.
     """
+    ln = LanguageContext(lang_key).get_target_language()
+    assert ln is not None
+    expected_header = gen_paths.out_dir / \
+        Path('nunavut') / \
+        Path('support') / \
+        Path('serialization').with_suffix(ln.extension)
     root_namespace_dir = gen_paths.dsdl_dir / Path("basic")
     generate_types(lang_key,
                    root_namespace_dir,
                    gen_paths.out_dir,
                    omit_serialization_support=False,
                    allow_unregulated_fixed_port_id=True)
+
+    assert expected_header.exists()

--- a/test/gentest_tests/test_tests.py
+++ b/test/gentest_tests/test_tests.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from pydsdl import read_namespace
 
 from nunavut import build_namespace_tree
-from nunavut.jinja import Generator
+from nunavut.jinja import DSDLCodeGenerator
 from nunavut.lang import LanguageContext
 
 
@@ -25,7 +25,7 @@ def test_instance_tests(gen_paths):  # type: ignore
                                      root_namespace_dir,
                                      gen_paths.out_dir,
                                      language_context)
-    generator = Generator(namespace, templates_dir=gen_paths.templates_dir)
+    generator = DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir)
     generator.generate_all(False)
 
     outfile = gen_paths.find_outfile_in_namespace("buncho.serializables", namespace)


### PR DESCRIPTION
WIth this change the support headers can be `.j2` Jinja templates. When they are rendered there will be no `T` available (i.e. these are not generated per-type) but the target language environment will be available including language options like `option_target_endianness`.