### PR TITLE
Docs CSS: fix display on wide screens

### DIFF
--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -2,3 +2,6 @@ p.first {
     white-space: normal;
     width: 30em;
 }
+.wy-nav-content {
+    max-width: unset;
+}

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 __license__ = 'MIT'


### PR DESCRIPTION
I am not particularly opinionated about this but I was just working on moving the PyDSDL docs to ReadTheDocs and I thought that I should introduce the layout fix into Nunavut as well because this doesn't look right:

<img src="https://user-images.githubusercontent.com/3298404/90308279-d8d67880-dee6-11ea-9c8a-7b7623c10661.png">

The effect of this change can be seen in the PyUAVCAN docs.

I wonder if I should propose this fix upstream...