### PR TITLE
[C serialization] Fix recursion issue in init_field

### DIFF
--- a/src/nunavut/lang/c/templates/_composite_type.j2
+++ b/src/nunavut/lang/c/templates/_composite_type.j2
@@ -68,10 +68,10 @@ inline void {{ composite_type | full_reference_name }}_init({{ composite_type | 
         {%- else %}
         {%- if composite_type is UnionType %}
         out_instance->_tag_ = 0;
-        {{ init_macros.init_field("out_instance", composite_type.fields[0]) }}
+        {{ init_macros.init_field(composite_type.fields[0]) }}
         {%- else -%}
         {%- for field in composite_type.fields %}
-        {{ init_macros.init_field("out_instance", field) }}
+        {{ init_macros.init_field(field) }}
         {%- endfor %}
         {%- endif -%}
         {%- endif %}

--- a/src/nunavut/lang/c/templates/_init_macros.j2
+++ b/src/nunavut/lang/c/templates/_init_macros.j2
@@ -1,21 +1,29 @@
-{%- macro init_field(instance_ptr_token, field, index='') -%}
-    {%- if field is not padding -%}
-    {%- if field.data_type is CompositeType -%}
-        {{ field.data_type | declaration }}_init(&({{ instance_ptr_token }}->{{ field | id }}{{ index }}));
-    {%- elif field.data_type is FixedLengthArrayType -%}
-        {%- if field.data_type.element_type is PrimitiveType -%}
-        memset(&({{ instance_ptr_token }}->{{ field | id }}[0]), 0, sizeof({{ field.data_type | declaration }}) * {{ field.data_type.capacity }});
+{%- macro init_field(field, data_type=None, ref='out_instance->') -%}
+    {%- if field is None -%}
+        {%- set _data_type = data_type -%}
+        {%- set _out = ref -%}
+    {%- else -%}
+        {%- set _data_type = field.data_type -%}
+        {%- set _out = ref + (field | id) -%}
+    {%- endif -%}
+
+    {%- if field is not padding or field is None -%}
+    {%- if _data_type is CompositeType -%}
+        {{ _data_type | declaration }}_init(&({{ _out }}));
+    {%- elif _data_type is FixedLengthArrayType -%}
+        {%- if _data_type.element_type is PrimitiveType -%}
+        memset(&({{ _out }}[0]), 0, sizeof({{ _data_type | declaration }}) * {{ field.data_type.capacity }});
         {%- else -%}
-             {%- for index in range(field.data_type.capacity) %}
-                {{ init_field(instance_ptr_token, field, '[{}]'.format(index)) }}
+             {%- for index in range(_data_type.capacity) -%}
+                {{ init_field(None, _data_type.element_type, '{}[{}]'.format(ref, index)) }}
              {%- endfor %}
         {%- endif -%}
-    {%- elif field.data_type is VariableLengthArrayType -%}
-        {{ instance_ptr_token }}->{{ field | id }}_length = 0;
+    {%- elif _data_type is VariableLengthArrayType -%}
+        {{ _out }}_length = 0;
     {%- else -%}
-        {{ instance_ptr_token }}->{{ field | id }}{{ index }} = 0;
+        {{ _out }} = 0;
     {%- endif -%}
     {%- else -%}
-        /* Ignoring {{ field.data_type.bit_length }} padding bit(s). */
+        /* Ignoring {{ _data_type.bit_length }} padding bit(s). */
     {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
This is my first kick at the can.

I haven't done any more than the simplest amount of testing.

The most obvious solution in my mind was to modify it to be more in line with how I did it in the serialization code, because you cannot always know the field "name", so it's easier to pass strings down than it is to extract semantics like that.

It *seems* to work on the BatteryPackParams type that it originally crashed on, but I haven't checked anything else,
and I'm especially concerned about how it'll handle multi-dimensional arrays.