### PR TITLE
Use POSIX-style paths in #includes

### DIFF
--- a/src/nunavut/lang/_common.py
+++ b/src/nunavut/lang/_common.py
@@ -39,7 +39,7 @@ class IncludeGenerator(DependencyBuilder):
             namespace_path = pathlib.Path('')
             for namespace_part in self._language.support_namespace:
                 namespace_path = namespace_path / pathlib.Path(namespace_part)
-            path_list += [str(namespace_path / pathlib.Path(p.name).with_suffix(output_extension))
+            path_list += [(namespace_path / pathlib.Path(p.name).with_suffix(output_extension)).as_posix()
                           for p in self._language.support_files]
 
         prefer_system_includes = bool(self._language.get_config_value_as_bool('prefer_system_includes', False))

--- a/src/nunavut/lang/_common.py
+++ b/src/nunavut/lang/_common.py
@@ -98,7 +98,7 @@ class IncludeGenerator(DependencyBuilder):
     def _make_path(self, dt: pydsdl.CompositeType, output_extension: str) -> str:
         short_name = self._short_reference_name_filter(self._language, dt)
         ns_path = pathlib.Path(*self._make_ns_list(dt)) / pathlib.Path(short_name).with_suffix(output_extension)
-        return str(ns_path)
+        return ns_path.as_posix()
 
     def _make_ns_list(self, dt: pydsdl.SerializableType) -> typing.List[str]:
         if self._language.enable_stropping:

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 __license__ = 'MIT'


### PR DESCRIPTION
The `__str__()` method of a `pathlib.Path` [is platform-dependent](https://docs.python.org/3.8/library/pathlib.html#operators).  We were using this when generating `#include` directives, but to produce host-independent C/C++ code we probably shouldn't (e.g. so that code generated on Windows can compile on a Linux system without Windows-style).

The current behaviour ultimately stems from the fact that the implementation presented at `pathlib.Path` depends on the interpreter host platform.  These are individually available as the `PosixPath` and `WindowsPath` classes.

An alternative to this PR would be to use `pathlib.PosixPath` (or `PurePosixPath`) around the code explicitly, rather than relying on platform-dependent behaviour.  However, it would probably be a much bigger diff than this tiny change.  I think keeping things as platform-native `Path` objects would be better, for instance so that the same path variable can be used to query the real filesystem without surprises.

Closes #129.