### PR TITLE
fix for issue #142

### DIFF
--- a/src/nunavut/cli.py
+++ b/src/nunavut/cli.py
@@ -65,14 +65,11 @@ def _run(args: argparse.Namespace, extra_includes: typing.List[str]) -> int:  # 
         # a valid target language.
         setattr(args, 'output_extension', '.tmp')
 
-    language_options = None
-
-    if args.target_language is not None:
-        language_options = dict()
-        if args.target_endianness is not None:
-            language_options['target_endianness'] = args.target_endianness
-        language_options['omit_float_serialization_support'] = args.omit_float_serialization_support
-        language_options['enable_serialization_asserts'] = args.enable_serialization_asserts
+    language_options = dict()
+    if args.target_endianness is not None:
+        language_options['target_endianness'] = args.target_endianness
+    language_options['omit_float_serialization_support'] = args.omit_float_serialization_support
+    language_options['enable_serialization_asserts'] = args.enable_serialization_asserts
 
     language_context = nunavut.lang.LanguageContext(
         args.target_language,

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 
 __license__ = 'MIT'


### PR DESCRIPTION
One line fix: since we don't consume language_options unless we select a target language it's fine to just always pass it in.