### PR TITLE
Hide WIP languages behind experimental flags (#172)

### DIFF
--- a/src/nunavut/cli.py
+++ b/src/nunavut/cli.py
@@ -271,7 +271,7 @@ def _make_parser() -> argparse.ArgumentParser:
 
     ''').lstrip())
 
-    parser.add_argument('--experimental-language', '-Xlang', nargs='*',
+    parser.add_argument('--experimental-language', '-Xlang', nargs='*', default=[],
                         help=textwrap.dedent('''
 
         Enable support for the given target language for this invocation of

--- a/src/nunavut/cli.py
+++ b/src/nunavut/cli.py
@@ -76,7 +76,8 @@ def _run(args: argparse.Namespace, extra_includes: typing.List[str]) -> int:  # 
         args.output_extension,
         args.namespace_output_stem,
         omit_serialization_support_for_target=args.omit_serialization_support,
-        language_options=language_options)
+        language_options=language_options,
+        allow_experimental_support=(args.target_language in args.experimental_language))
 
     #
     # nunavut: inferred target language from extension
@@ -98,7 +99,8 @@ def _run(args: argparse.Namespace, extra_includes: typing.List[str]) -> int:  # 
                 args.output_extension,
                 args.namespace_output_stem,
                 omit_serialization_support_for_target=args.omit_serialization_support,
-                language_options=language_options)
+                language_options=language_options,
+                allow_experimental_support=(args.target_language in args.experimental_language))
         elif args.templates is None:
             logging.warn(
                 textwrap.dedent('''
@@ -266,6 +268,20 @@ def _make_parser() -> argparse.ArgumentParser:
 
         If provided then the output extension (--e) can be inferred otherwise the output
         extension must be provided.
+
+    ''').lstrip())
+
+    parser.add_argument('--experimental-language', '-Xlang', nargs='*',
+                        help=textwrap.dedent('''
+
+        Enable support for the given target language for this invocation of
+        nunavut, even if still experimental.  This option may be specified
+        multiple times, once per language, to simplify scripted invocations.
+
+        By default, target languages where support is not finalised are not
+        enabled when running nunavut, to make it clear that the code output
+        may change in a non-backwards-compatible way in future versions, or
+        simply might not be complete and working yet.
 
     ''').lstrip())
 

--- a/src/nunavut/lang/__init__.py
+++ b/src/nunavut/lang/__init__.py
@@ -442,7 +442,7 @@ class LanguageContext:
                 raise KeyError('{} is not a supported language'.format(target_language))
 
             # Assume a language's support is experimental unless explicitly configured otherwise
-            language_is_experimental = self._config.get('nunavut.lang.{}', 'experimental', fallback=True)
+            language_is_experimental = self._config.get('nunavut.lang.{}', 'experimental_support', fallback=True)
             if language_is_experimental and not allow_experimental_support:
                 raise KeyError('Target language support for {} is still experimental, '
                                'so its use must be explicitly enabled'.format(target_language))

--- a/src/nunavut/lang/__init__.py
+++ b/src/nunavut/lang/__init__.py
@@ -185,6 +185,13 @@ class Language:
         return self._config.getboolean(self._section, 'has_standard_namespace_files')
 
     @property
+    def support_is_experimental(self) -> bool:
+        """
+        Whether support for this language is still only experimental.
+        """
+        return self._config.getboolean(self._section, 'experimental_support', fallback=True)
+
+    @property
     def omit_serialization_support(self) -> bool:
         """
         If True then generators should not include serialization routines, types,
@@ -441,9 +448,7 @@ class LanguageContext:
             except ImportError:
                 raise KeyError('{} is not a supported language'.format(target_language))
 
-            # Assume a language's support is experimental unless explicitly configured otherwise
-            language_is_experimental = self._config.get('nunavut.lang.{}', 'experimental_support', fallback=True)
-            if language_is_experimental and not allow_experimental_support:
+            if self._target_language.support_is_experimental and not allow_experimental_support:
                 raise KeyError('Target language support for {} is still experimental, '
                                'so its use must be explicitly enabled'.format(target_language))
 

--- a/src/nunavut/lang/properties.ini
+++ b/src/nunavut/lang/properties.ini
@@ -1,6 +1,7 @@
 
 [nunavut.lang.c]
 extension = .h
+experimental_support = False
 namespace_file_stem = _namespace_
 has_standard_namespace_files = False
 namespace_is_composite_type = False
@@ -240,6 +241,7 @@ options = ${nunavut.lang.c:options}
 
 [nunavut.lang.py]
 extension = .py
+experimental_support = False
 has_standard_namespace_files = True
 namespace_is_composite_type = True
 namespace_file_stem = __init__

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 __license__ = 'MIT'

--- a/test/gentest_nnvg/test_nnvg.py
+++ b/test/gentest_nnvg/test_nnvg.py
@@ -137,6 +137,7 @@ def test_target_language(gen_paths: typing.Any, run_nnvg: typing.Callable) -> No
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-language', 'cpp',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--list-outputs',
                  '--omit-serialization-support',
@@ -157,6 +158,7 @@ def test_language_option_defaults(gen_paths: typing.Any, run_nnvg: typing.Callab
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-language', 'cpp',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
 
@@ -179,6 +181,7 @@ def test_language_option_overrides(target_endianness_override: str, gen_paths: t
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-language', 'cpp',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--target-endianness', target_endianness_override,
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
@@ -197,6 +200,7 @@ def test_language_option_target_endianness_illegal_option(gen_paths: typing.Any,
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-language', 'cpp',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--target-endianness', 'mixed',
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
@@ -215,6 +219,7 @@ def test_language_option_omit_floatingpoint(gen_paths: typing.Any, run_nnvg: typ
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-language', 'cpp',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--omit-float-serialization-support',
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
@@ -235,6 +240,7 @@ def test_language_option_generate_asserts(gen_paths: typing.Any, run_nnvg: typin
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-language', 'cpp',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--enable-serialization-asserts',
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
@@ -307,6 +313,7 @@ def test_language_allow_unregulated_fixed_portid(gen_paths: typing.Any, run_nnvg
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-language', 'cpp',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--list-outputs',
                  '--allow-unregulated-fixed-port-id',

--- a/tox.ini
+++ b/tox.ini
@@ -148,6 +148,7 @@ commands =
     nnvg:        -m nunavut \
     nnvg:        -O {envtmpdir} \
     nnvg:        --target-language cpp \
+    nnvg:        --experimental-language cpp \
     nnvg:        -v \
     nnvg:        --dry-run \
     nnvg:        {toxinidir}/submodules/public_regulated_data_types/uavcan
@@ -203,6 +204,7 @@ commands =
         -m nunavut \
             -O {envtmpdir} \
             --target-language cpp \
+            --experimental-language cpp \
             -v \
             {toxinidir}/submodules/public_regulated_data_types/uavcan
 

--- a/verification/cmake/modules/Findnnvg.cmake
+++ b/verification/cmake/modules/Findnnvg.cmake
@@ -49,6 +49,10 @@ function (create_dsdl_target ARG_TARGET_NAME
 
     list(APPEND NNVG_CMD_ARGS --target-language)
     list(APPEND NNVG_CMD_ARGS ${ARG_OUTPUT_LANGUAGE})
+    # For verification suite purposes we don't care if the language support is
+    # experimental or not, so specify that it can be used regardless
+    list(APPEND NNVG_CMD_ARGS --experimental-language)
+    list(APPEND NNVG_CMD_ARGS ${ARG_OUTPUT_LANGUAGE})
     list(APPEND NNVG_CMD_ARGS  -O)
     list(APPEND NNVG_CMD_ARGS ${ARG_OUTPUT_FOLDER})
     list(APPEND NNVG_CMD_ARGS ${ARG_DSDL_ROOT_DIR})


### PR DESCRIPTION
This is an attempt at solving #172.

Summary:

Add CLI argument `--experimental-language` / `-Xlang`.  Use like `nunavut -l cpp -Xlang cpp [...other options]`.

Design choices I made, which are open to critique:
- That languages are assumed experimental by default, until we set `experimental = False` for them in properties.ini
- Keeping the door open for adding other experimental feature-kinds in future, by leaving the CLI arguments longer than they could be.  I'm thinking we could have an `--experimental-foo`/`-Xfoo` down the line.
- Taking advantage of argparse's `nargs` option, which is a bit cleaner than taking one comma-separated list of experimental languages (which we'd have to parse ourselves).  This matches the kind of format you see in compilers too, e.g. clang or gcc's `-I`, `-W`, `-f` option sets, which would be a nice alignment given nunavut's adjacency as a build pipeline tool.

Closes #172.