### PR TITLE
Differentiate between stable/experimental languages in API and CLI

### DIFF
--- a/src/nunavut/cli.py
+++ b/src/nunavut/cli.py
@@ -76,7 +76,8 @@ def _run(args: argparse.Namespace, extra_includes: typing.List[str]) -> int:  # 
         args.output_extension,
         args.namespace_output_stem,
         omit_serialization_support_for_target=args.omit_serialization_support,
-        language_options=language_options)
+        language_options=language_options,
+        include_experimental_languages=args.experimental_languages)
 
     #
     # nunavut: inferred target language from extension
@@ -266,6 +267,19 @@ def _make_parser() -> argparse.ArgumentParser:
 
         If provided then the output extension (--e) can be inferred otherwise the output
         extension must be provided.
+
+    ''').lstrip())
+
+    parser.add_argument('--experimental-languages', '-Xlang',
+                        action='store_true',
+                        help=textwrap.dedent('''
+
+        Activate languages with unstable, experimental support.
+
+        By default, target languages where support is not finalised are not
+        enabled when running nunavut, to make it clear that the code output
+        may change in a non-backwards-compatible way in future versions, or
+        that it might not even work yet.
 
     ''').lstrip())
 

--- a/src/nunavut/lang/__init__.py
+++ b/src/nunavut/lang/__init__.py
@@ -456,15 +456,18 @@ class LanguageContext:
                 self._config.set('nunavut.lang.{}'.format(target_language),
                                  'extension',
                                  extension)
-
             self._languages[target_language] = self._target_language
 
         # create remaining languages
         remaining_languages = set(self.get_supported_language_names()) - set((target_language,))
-        for language_name in remaining_languages:
+        self._populate_languages(remaining_languages, include_experimental_languages)
+
+    def _populate_languages(self, language_names: typing.Iterable[str],
+                            include_experimental: bool) -> None:
+        for language_name in language_names:
             try:
                 lang = Language(language_name, self._config, False)
-                if lang.stable_support or include_experimental_languages:
+                if lang.stable_support or include_experimental:
                     self._languages[language_name] = lang
             except ImportError:
                 raise KeyError('{} is not a supported language'.format(language_name))

--- a/src/nunavut/lang/properties.ini
+++ b/src/nunavut/lang/properties.ini
@@ -1,6 +1,7 @@
 
 [nunavut.lang.c]
 extension = .h
+stable_support = True
 namespace_file_stem = _namespace_
 has_standard_namespace_files = False
 namespace_is_composite_type = False
@@ -240,6 +241,7 @@ options = ${nunavut.lang.c:options}
 
 [nunavut.lang.py]
 extension = .py
+stable_support = True
 has_standard_namespace_files = True
 namespace_is_composite_type = True
 namespace_file_stem = __init__

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.6.6"
+__version__ = "0.7.0"
 
 __license__ = 'MIT'

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 __license__ = 'MIT'

--- a/test/gentest_nnvg/test_nnvg.py
+++ b/test/gentest_nnvg/test_nnvg.py
@@ -21,6 +21,7 @@ def test_UAVCAN_DSDL_INCLUDE_PATH(gen_paths: typing.Any, run_nnvg: typing.Callab
     nnvg_args0 = ['--templates', str(gen_paths.templates_dir),
                   '-O', str(gen_paths.out_dir),
                   '-e', '.json',
+                  '-Xlang',
                   str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
 
     with pytest.raises(subprocess.CalledProcessError):
@@ -40,6 +41,7 @@ def test_nnvg_heals_missing_dot_in_extension(gen_paths: typing.Any, run_nnvg: ty
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '-e', 'json',
+                 '-Xlang',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
 
@@ -107,6 +109,7 @@ def test_list_outputs(gen_paths: typing.Any, run_nnvg: typing.Callable) -> None:
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '-e', '.json',
+                 '-Xlang',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--list-outputs',
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
@@ -137,6 +140,7 @@ def test_target_language(gen_paths: typing.Any, run_nnvg: typing.Callable) -> No
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-languages',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--list-outputs',
                  '--omit-serialization-support',
@@ -157,6 +161,7 @@ def test_language_option_defaults(gen_paths: typing.Any, run_nnvg: typing.Callab
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-languages',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
 
@@ -179,6 +184,7 @@ def test_language_option_overrides(target_endianness_override: str, gen_paths: t
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-languages',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--target-endianness', target_endianness_override,
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
@@ -197,6 +203,7 @@ def test_language_option_target_endianness_illegal_option(gen_paths: typing.Any,
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-languages',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--target-endianness', 'mixed',
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
@@ -215,6 +222,7 @@ def test_language_option_omit_floatingpoint(gen_paths: typing.Any, run_nnvg: typ
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-languages',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--omit-float-serialization-support',
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
@@ -235,6 +243,7 @@ def test_language_option_generate_asserts(gen_paths: typing.Any, run_nnvg: typin
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-languages',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--enable-serialization-asserts',
                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
@@ -307,6 +316,7 @@ def test_language_allow_unregulated_fixed_portid(gen_paths: typing.Any, run_nnvg
     nnvg_args = ['--templates', str(gen_paths.templates_dir),
                  '-O', str(gen_paths.out_dir),
                  '--target-language', 'cpp',
+                 '--experimental-languages',
                  '-I', str(gen_paths.dsdl_dir / pathlib.Path('scotec')),
                  '--list-outputs',
                  '--allow-unregulated-fixed-port-id',

--- a/tox.ini
+++ b/tox.ini
@@ -148,6 +148,7 @@ commands =
     nnvg:        -m nunavut \
     nnvg:        -O {envtmpdir} \
     nnvg:        --target-language cpp \
+    nnvg:        --experimental-languages \
     nnvg:        -v \
     nnvg:        --dry-run \
     nnvg:        {toxinidir}/submodules/public_regulated_data_types/uavcan
@@ -203,6 +204,7 @@ commands =
         -m nunavut \
             -O {envtmpdir} \
             --target-language cpp \
+            --experimental-languages \
             -v \
             {toxinidir}/submodules/public_regulated_data_types/uavcan
 


### PR DESCRIPTION
A second approach to denoting 'experimental' languages (i.e. anything that's not C or Python for v1.0).

Controversially, I've chosen for the CLI to default to supplying `include_experimental_languages` as `False` when creating a LanguageContext, although in `LanguageContext.__init__` itself the default is `True`.  This would mean that most of the test code (and any Pythonic users of nunavut rather than CLI users) will have experimental languages available by default -- let me know how you feel about this.  My main motivations for that choice are that the bulk of the test code, which uses C++ and JSON outputs, can be left intact this way, and that the original issue #172 seems concerned mainly with CLI users.

@thirtytwobits please correct me if wrong - is Python stable, or is it just C right now?

Resolves #172.
Closes #173 by obsolence.