### PR TITLE
Fix missing .format in experimental language warning

### DIFF
--- a/src/nunavut/lang/__init__.py
+++ b/src/nunavut/lang/__init__.py
@@ -454,7 +454,10 @@ class LanguageContext:
             except ImportError:
                 raise KeyError('{} is not a supported language'.format(target_language))
             if not (self._target_language.stable_support or include_experimental_languages):
-                raise ValueError('{} support is only experimental, but experimental language support is not enabled')
+                raise ValueError(
+                    '{} support is only experimental, but experimental language support is not enabled'
+                    .format(target_language)
+                )
             if namespace_output_stem is not None:
                 self._config.set('nunavut.lang.{}'.format(target_language),
                                  'namespace_file_stem',


### PR DESCRIPTION
Really small PR here. Noticed that there was a missing .format() on this warning, so I added it.

Not sure how strict the issue -> PR etiquette is on this project - this is just a one-line bugfix, but if the procedure is to open an issue then I can open one.