### PR TITLE
Allow override ARRAY_CAPACITY in variable array 

### DIFF
--- a/.buildkite/verify.py
+++ b/.buildkite/verify.py
@@ -177,6 +177,9 @@ def _cmake_configure(args: argparse.Namespace, cmake_args: typing.List[str], cma
         if args.disable_fp:
             cmake_configure_args.append('-DNUNAVUT_VERIFICATION_SER_FP_DISABLE:BOOL=ON')
 
+        if args.enable_override_variable_array_capacity:
+            cmake_configure_args.append('-DNUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE:BOOL=ON')
+
         if args.verbose > 0:
             cmake_configure_args.append('-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON')
 

--- a/.buildkite/verify.py
+++ b/.buildkite/verify.py
@@ -55,9 +55,9 @@ def _make_parser() -> argparse.ArgumentParser:
                         action='store_true',
                         help='Set NUNAVUT_VERIFICATION_SER_FP_DISABLE=ON (default is OFF)')
 
-    parser.add_argument('--enable-override-variable-array-capacity',
+    parser.add_argument('--enable-ovr-var-array',
                         action='store_true',
-                        help='Set NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE=ON (default is OFF)')
+                        help='Set NUNAVUT_VERIFICATION_OVR_VAR_ARRAY_ENABLE=ON (default is OFF)')
 
     parser.add_argument('-v', '--verbose',
                         action='count',
@@ -177,8 +177,8 @@ def _cmake_configure(args: argparse.Namespace, cmake_args: typing.List[str], cma
         if args.disable_fp:
             cmake_configure_args.append('-DNUNAVUT_VERIFICATION_SER_FP_DISABLE:BOOL=ON')
 
-        if args.enable_override_variable_array_capacity:
-            cmake_configure_args.append('-DNUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE:BOOL=ON')
+        if args.enable_ovr_var_array:
+            cmake_configure_args.append('-NUNAVUT_VERIFICATION_OVR_VAR_ARRAY_ENABLE:BOOL=ON')
 
         if args.verbose > 0:
             cmake_configure_args.append('-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON')

--- a/.buildkite/verify.py
+++ b/.buildkite/verify.py
@@ -55,6 +55,10 @@ def _make_parser() -> argparse.ArgumentParser:
                         action='store_true',
                         help='Set NUNAVUT_VERIFICATION_SER_FP_DISABLE=ON (default is OFF)')
 
+    parser.add_argument('--enable-override-variable-array-capacity',
+                        action='store_true',
+                        help='Set NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE=ON (default is OFF)')
+
     parser.add_argument('-v', '--verbose',
                         action='count',
                         default=0,

--- a/.buildkite/verify_c_amd64.sh
+++ b/.buildkite/verify_c_amd64.sh
@@ -11,6 +11,6 @@ function run()
 run  --endianness little  --platform native64  --build-type Debug
 run  --endianness little  --platform native64  --build-type Release
 run  --endianness little  --platform native64  --build-type MinSizeRel  --disable-asserts
-run  --endianness little  --platform native64  --build-type Debug       --enable-override-variable-array-capacity
-run  --endianness little  --platform native64  --build-type Release     --enable-override-variable-array-capacity
-run  --endianness little  --platform native64  --build-type MinSizeRel  --enable-override-variable-array-capacity
+run  --endianness little  --platform native64  --build-type Debug       --enable-ovr-var-array
+run  --endianness little  --platform native64  --build-type Release     --enable-ovr-var-array
+run  --endianness little  --platform native64  --build-type MinSizeRel  --enable-ovr-var-array

--- a/.buildkite/verify_c_amd64.sh
+++ b/.buildkite/verify_c_amd64.sh
@@ -11,3 +11,6 @@ function run()
 run  --endianness little  --platform native64  --build-type Debug
 run  --endianness little  --platform native64  --build-type Release
 run  --endianness little  --platform native64  --build-type MinSizeRel  --disable-asserts
+run  --endianness little  --platform native64  --build-type Debug       --enable-override-variable-array-capacity
+run  --endianness little  --platform native64  --build-type Release     --enable-override-variable-array-capacity
+run  --endianness little  --platform native64  --build-type MinSizeRel  --enable-override-variable-array-capacity

--- a/.buildkite/verify_c_x86.sh
+++ b/.buildkite/verify_c_x86.sh
@@ -11,3 +11,6 @@ function run()
 run  --endianness any  --platform native32  --build-type Debug
 run  --endianness any  --platform native32  --build-type Release
 run  --endianness any  --platform native32  --build-type MinSizeRel  --disable-asserts
+run  --endianness any  --platform native32  --build-type Debug       --enable-override-variable-array-capacity
+run  --endianness any  --platform native32  --build-type Release     --enable-override-variable-array-capacity
+run  --endianness any  --platform native32  --build-type MinSizeRel  --enable-override-variable-array-capacity

--- a/.buildkite/verify_c_x86.sh
+++ b/.buildkite/verify_c_x86.sh
@@ -11,6 +11,7 @@ function run()
 run  --endianness any  --platform native32  --build-type Debug
 run  --endianness any  --platform native32  --build-type Release
 run  --endianness any  --platform native32  --build-type MinSizeRel  --disable-asserts
-run  --endianness any  --platform native32  --build-type Debug       --enable-override-variable-array-capacity
-run  --endianness any  --platform native32  --build-type Release     --enable-override-variable-array-capacity
-run  --endianness any  --platform native32  --build-type MinSizeRel  --enable-override-variable-array-capacity
+run  --endianness any  --platform native32  --build-type Debug       --enable-ovr-var-array
+run  --endianness any  --platform native32  --build-type Release     --enable-ovr-var-array
+run  --endianness any  --platform native32  --build-type MinSizeRel  --enable-ovr-var-array
+

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -79,14 +79,14 @@ and running do::
 To run a limited suite using only locally available interpreters directly on your host machine,
 skip the docker invocations and use ``tox -s``.
 
-To run the language verification build you'll need to use a different docker container:
+To run the language verification build you'll need to use a different docker container::
 
     docker pull uavcan/c_cpp:ubuntu-18.04
     docker run --rm -it -v $PWD:/repo uavcan/c_cpp:ubuntu-18.04
     ./.buildkite/verify.py -l c
     ./.buildkite/verify.py -l cpp
 
-The verify.py script is a simple commandline generator for our cmake scripts. Use help for details:
+The verify.py script is a simple commandline generator for our cmake scripts. Use help for details::
 
     ./.buildkite/verify.py --help
 

--- a/src/nunavut/cli.py
+++ b/src/nunavut/cli.py
@@ -539,7 +539,7 @@ def _make_parser() -> argparse.ArgumentParser:
 
     ''').lstrip())
 
-    ln_opt_group.add_argument('--enable_override_variable_array_capacity',
+    ln_opt_group.add_argument('--enable-override-variable-array-capacity',
                               action='store_true',
                               help=textwrap.dedent('''
 

--- a/src/nunavut/cli.py
+++ b/src/nunavut/cli.py
@@ -544,7 +544,7 @@ def _make_parser() -> argparse.ArgumentParser:
                               help=textwrap.dedent('''
 
         Instruct support header generators to add the possiblitiy to override max capacity of a 
-        variable length array in serialization routines. This will option will disable serialization
+        variable length array in serialization routines. This option will disable serialization
         buffer checks and add conditional compilation statements which violates MISRA.
 
     ''').lstrip())

--- a/src/nunavut/cli.py
+++ b/src/nunavut/cli.py
@@ -543,7 +543,7 @@ def _make_parser() -> argparse.ArgumentParser:
                               action='store_true',
                               help=textwrap.dedent('''
 
-        Instruct support header generators to add the possiblitiy to override max capacity of a 
+        Instruct support header generators to add the possiblitiy to override max capacity of a
         variable length array in serialization routines. This option will disable serialization
         buffer checks and add conditional compilation statements which violates MISRA.
 

--- a/src/nunavut/cli.py
+++ b/src/nunavut/cli.py
@@ -71,6 +71,7 @@ def _run(args: argparse.Namespace, extra_includes: typing.List[str]) -> int:  # 
         language_options['target_endianness'] = args.target_endianness
     language_options['omit_float_serialization_support'] = args.omit_float_serialization_support
     language_options['enable_serialization_asserts'] = args.enable_serialization_asserts
+    language_options['enable_override_variable_array_capacity'] = args.enable_override_variable_array_capacity
 
     language_context = nunavut.lang.LanguageContext(
         args.target_language,
@@ -535,6 +536,16 @@ def _make_parser() -> argparse.ArgumentParser:
         based on documented requirements for calling logic that could expose a system to undefined
         behaviour. The alternative, for langauges that do not support exception handling, is to
         use assertions designed to halt a program rather than execute undefined logic.
+
+    ''').lstrip())
+
+    ln_opt_group.add_argument('--enable_override_variable_array_capacity',
+                              action='store_true',
+                              help=textwrap.dedent('''
+
+        Instruct support header generators to add the possiblitiy to override max capacity of a 
+        variable length array in serialization routines. This will option will disable serialization
+        buffer checks and add conditional compilation statements which violates MISRA.
 
     ''').lstrip())
 

--- a/src/nunavut/lang/c/templates/definitions.j2
+++ b/src/nunavut/lang/c/templates/definitions.j2
@@ -51,8 +51,11 @@ static_assert({{ t | full_reference_name }}_EXTENT_BYTES_ >= {# -#}
 {%- endif %}
 #define {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_           {{ f.data_type.capacity }}U
 {%- if options.enable_override_variable_array_capacity and f.data_type is VariableLengthArrayType %}
-#elif {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_ > {{ f.data_type.capacity }}U
-#error {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_ > {{ f.data_type.capacity }}U
+#elif !defined(reg_drone_service_battery_Status_0_2_DISABLE_SERIALIZATION_BUFFER_CHECK)
+#  define reg_drone_service_battery_Status_0_2_DISABLE_SERIALIZATION_BUFFER_CHECK
+#endif
+#if {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_ > {{ f.data_type.capacity }}U
+#  error {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_ > {{ f.data_type.capacity }}U
 #endif
 {%- endif %}
 #define {{ t | full_reference_name }}_{{ f.name }}_ARRAY_IS_VARIABLE_LENGTH_ {# -#}

--- a/src/nunavut/lang/c/templates/definitions.j2
+++ b/src/nunavut/lang/c/templates/definitions.j2
@@ -142,7 +142,7 @@ struct  /// Array address equivalence guarantee: &elements[0] == &{{ name }}
     {%- if f.element_type is BooleanType %}
     {{ _define_bitpacked_array_field('bitpacked', f.capacity) | indent }};
     {%- else %}
-    {{ _define_field(t, f.element_type, 'elements', '[%s_%s_ARRAY_CAPACITY_]'|format(t | full_reference_name, name)) }};
+    {{ _define_field(t, f.element_type, 'elements', '[%s_%s_ARRAY_CAPACITY_]'|format(t|full_reference_name, name)) }};
     {%- endif %}
     {{ typename_unsigned_length }} count;
 } {{ name | id }}{{ suffix }}

--- a/src/nunavut/lang/c/templates/definitions.j2
+++ b/src/nunavut/lang/c/templates/definitions.j2
@@ -46,11 +46,13 @@ static_assert({{ t | full_reference_name }}_EXTENT_BYTES_ >= {# -#}
 {%- endfor %}
 {% for f in t.fields_except_padding if f.data_type is ArrayType %}
 /// Array metadata for: {{ f }}
-{%- if f.data_type is VariableLengthArrayType %}
+{%- if options.enable_override_variable_array_capacity and f.data_type is VariableLengthArrayType %}
 #ifndef {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_
 {%- endif %}
 #define {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_           {{ f.data_type.capacity }}U
-{%- if f.data_type is VariableLengthArrayType %}
+{%- if options.enable_override_variable_array_capacity and f.data_type is VariableLengthArrayType %}
+#elif {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_ > {{ f.data_type.capacity }}U
+#error {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_ > {{ f.data_type.capacity }}U
 #endif
 {%- endif %}
 #define {{ t | full_reference_name }}_{{ f.name }}_ARRAY_IS_VARIABLE_LENGTH_ {# -#}

--- a/src/nunavut/lang/c/templates/definitions.j2
+++ b/src/nunavut/lang/c/templates/definitions.j2
@@ -46,7 +46,13 @@ static_assert({{ t | full_reference_name }}_EXTENT_BYTES_ >= {# -#}
 {%- endfor %}
 {% for f in t.fields_except_padding if f.data_type is ArrayType %}
 /// Array metadata for: {{ f }}
+{%- if f.data_type is VariableLengthArrayType %}
+#ifndef {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_
+{%- endif %}
 #define {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_           {{ f.data_type.capacity }}U
+{%- if f.data_type is VariableLengthArrayType %}
+#endif
+{%- endif %}
 #define {{ t | full_reference_name }}_{{ f.name }}_ARRAY_IS_VARIABLE_LENGTH_ {# -#}
         {{ valuetoken_true if f.data_type is VariableLengthArrayType else valuetoken_false }}
 {%- endfor %}
@@ -87,7 +93,7 @@ typedef struct
         {# Blank line between fields. #}
     {%- endif %}
     /// {{ f }}
-    {{ _define_field(f.data_type, f.name) | indent }};
+    {{ _define_field(t, f.data_type, f.name) | indent }};
 {%- else %}{#- To maintain consistency between C and C++ we define any empty composite type with a dummy byte. #}
     {{ typename_byte }} _dummy_;
 {%- endfor %}
@@ -107,7 +113,7 @@ typedef struct
             {# Blank line between fields. #}
         {%- endif %}
         /// {{ f }}
-        {{ _define_field(f.data_type, f.name) | indent | indent }};
+        {{ _define_field(t, f.data_type, f.name) | indent | indent }};
     {%- endfor %}
     };
     {{ t.tag_field_type | type_from_primitive }} _tag_;
@@ -116,27 +122,27 @@ typedef struct
 
 
 {# ----------------------------------------------------------------------------------------------------------------- #}
-{% macro _define_field(t, name, suffix='') %}
-{%- if t is PrimitiveType -%}
-{{ t | type_from_primitive }} {{ name | id }}{{ suffix }}
+{% macro _define_field(t, f, name, suffix='') %}
+{%- if f is PrimitiveType -%}
+{{ f | type_from_primitive }} {{ name | id }}{{ suffix }}
 
-{%- elif t is CompositeType -%}
-{{ t | full_reference_name }} {{ name | id }}{{ suffix }}
+{%- elif f is CompositeType -%}
+{{ f | full_reference_name }} {{ name | id }}{{ suffix }}
 
-{%- elif t is FixedLengthArrayType -%}
-    {%- if t.element_type is BooleanType -%}
-{{ _define_bitpacked_array_field(name + '_bitpacked_', t.capacity) }}{{ suffix }}
+{%- elif f is FixedLengthArrayType -%}
+    {%- if f.element_type is BooleanType -%}
+{{ _define_bitpacked_array_field(name + '_bitpacked_', f.capacity) }}{{ suffix }}
     {%- else -%}
-{{ _define_field(t.element_type, name, '[%s]'|format(t.capacity)) }}{{ suffix }}
+{{ _define_field(t, f.element_type, name, '[%s]'|format(f.capacity)) }}{{ suffix }}
     {%- endif -%}
 
-{%- elif t is VariableLengthArrayType -%}
+{%- elif f is VariableLengthArrayType -%}
 struct  /// Array address equivalence guarantee: &elements[0] == &{{ name }}
 {
-    {%- if t.element_type is BooleanType %}
-    {{ _define_bitpacked_array_field('bitpacked', t.capacity) | indent }};
+    {%- if f.element_type is BooleanType %}
+    {{ _define_bitpacked_array_field('bitpacked', f.capacity) | indent }};
     {%- else %}
-    {{ _define_field(t.element_type, 'elements', '[%s]'|format(t.capacity)) }};
+    {{ _define_field(t, f.element_type, 'elements', '[%s_%s_ARRAY_CAPACITY_]'|format(t | full_reference_name, name)) }};
     {%- endif %}
     {{ typename_unsigned_length }} count;
 } {{ name | id }}{{ suffix }}

--- a/src/nunavut/lang/c/templates/definitions.j2
+++ b/src/nunavut/lang/c/templates/definitions.j2
@@ -51,8 +51,8 @@ static_assert({{ t | full_reference_name }}_EXTENT_BYTES_ >= {# -#}
 {%- endif %}
 #define {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_           {{ f.data_type.capacity }}U
 {%- if options.enable_override_variable_array_capacity and f.data_type is VariableLengthArrayType %}
-#elif !defined(reg_drone_service_battery_Status_0_2_DISABLE_SERIALIZATION_BUFFER_CHECK)
-#  define reg_drone_service_battery_Status_0_2_DISABLE_SERIALIZATION_BUFFER_CHECK
+#elif !defined({{ t | full_reference_name }}_DISABLE_SERIALIZATION_BUFFER_CHECK_)
+#  define {{ t | full_reference_name }}_DISABLE_SERIALIZATION_BUFFER_CHECK_
 #endif
 #if {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_ > {{ f.data_type.capacity }}U
 #  error {{ t | full_reference_name }}_{{ f.name }}_ARRAY_CAPACITY_ > {{ f.data_type.capacity }}U

--- a/src/nunavut/lang/c/templates/serialization.j2
+++ b/src/nunavut/lang/c/templates/serialization.j2
@@ -28,10 +28,12 @@
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _serialize_impl(t) %}
     const {{ typename_unsigned_length }} capacity_bytes = *inout_buffer_size_bytes;
+{%- if not options.enable_override_variable_array_capacity %}
     if ((8U * ({{ typename_unsigned_bit_length }}) capacity_bytes) < {{ t.inner_type.bit_length_set|max }}UL)
     {
         return -NUNAVUT_ERROR_SERIALIZATION_BUFFER_TOO_SMALL;
     }
+{% endif %}
     // Notice that fields that are not an integer number of bytes long may overrun the space allocated for them
     // in the serialization buffer up to the next byte boundary. This is by design and is guaranteed to be safe.
     {{ typename_unsigned_bit_length }} offset_bits = 0U;

--- a/src/nunavut/lang/c/templates/serialization.j2
+++ b/src/nunavut/lang/c/templates/serialization.j2
@@ -28,11 +28,15 @@
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _serialize_impl(t) %}
     const {{ typename_unsigned_length }} capacity_bytes = *inout_buffer_size_bytes;
-{%- if not options.enable_override_variable_array_capacity %}
+{%- if options.enable_override_variable_array_capacity %}
+#ifndef reg_drone_service_battery_Status_0_2_DISABLE_SERIALIZATION_BUFFER_CHECK
+{% endif %}
     if ((8U * ({{ typename_unsigned_bit_length }}) capacity_bytes) < {{ t.inner_type.bit_length_set|max }}UL)
     {
         return -NUNAVUT_ERROR_SERIALIZATION_BUFFER_TOO_SMALL;
     }
+{%- if options.enable_override_variable_array_capacity %}
+#endif
 {% endif %}
     // Notice that fields that are not an integer number of bytes long may overrun the space allocated for them
     // in the serialization buffer up to the next byte boundary. This is by design and is guaranteed to be safe.

--- a/src/nunavut/lang/c/templates/serialization.j2
+++ b/src/nunavut/lang/c/templates/serialization.j2
@@ -29,7 +29,7 @@
 {% macro _serialize_impl(t) %}
     const {{ typename_unsigned_length }} capacity_bytes = *inout_buffer_size_bytes;
 {%- if options.enable_override_variable_array_capacity %}
-#ifndef reg_drone_service_battery_Status_0_2_DISABLE_SERIALIZATION_BUFFER_CHECK
+#ifndef {{ t | full_reference_name }}_DISABLE_SERIALIZATION_BUFFER_CHECK_
 {% endif %}
     if ((8U * ({{ typename_unsigned_bit_length }}) capacity_bytes) < {{ t.inner_type.bit_length_set|max }}UL)
     {

--- a/src/nunavut/lang/properties.ini
+++ b/src/nunavut/lang/properties.ini
@@ -212,6 +212,7 @@ options =
     target_endianness = any
     omit_float_serialization_support = false
     enable_serialization_asserts = false
+    enable_override_variable_array_capacity = false
 
 [nunavut.lang.cpp]
 extension = .hpp

--- a/test/gentest_nnvg/templates/Any.j2
+++ b/test/gentest_nnvg/templates/Any.j2
@@ -9,4 +9,7 @@
 {%- if options.enable_serialization_asserts is defined %},
      "enable_serialization_asserts": {{ options.enable_serialization_asserts | ln.js.to_true_or_false }}
 {% endif %}
+{%- if options.enable_override_variable_array_capacity is defined %},
+     "enable_override_variable_array_capacity": {{ options.enable_override_variable_array_capacity | ln.js.to_true_or_false }}
+{% endif %}
 }

--- a/verification/CMakeLists.txt
+++ b/verification/CMakeLists.txt
@@ -50,6 +50,10 @@ if(NOT DEFINED NUNAVUT_VERIFICATION_SER_FP_DISABLE)
      set(NUNAVUT_VERIFICATION_SER_FP_DISABLE OFF CACHE BOOL "Enable or disable floating point support in generated support code.")
 endif()
 
+if(NOT DEFINED NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE)
+     set(NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE OFF CACHE BOOL "Enable or disable optional variable array capacity override in generated code.")
+endif()
+
 if (NUNAVUT_VERIFICATION_LANG STREQUAL "cpp")
     set(NUNAVUT_VERIFICATION_ROOT "${CMAKE_SOURCE_DIR}/cpp")
     message(STATUS "NUNAVUT_VERIFICATION_LANG is C++ (${NUNAVUT_VERIFICATION_LANG})")
@@ -148,6 +152,7 @@ create_dsdl_target(nunavut-support
                    OFF
                    ${NUNAVUT_VERIFICATION_SER_ASSERT}
                    ${NUNAVUT_VERIFICATION_SER_FP_DISABLE}
+                   ${NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE}
                    ON
                    "${NUNAVUT_VERIFICATION_TARGET_ENDIANNESS}"
                    "only")
@@ -162,6 +167,7 @@ create_dsdl_target(dsdl-regulated
                    OFF
                    ${NUNAVUT_VERIFICATION_SER_ASSERT}
                    ${NUNAVUT_VERIFICATION_SER_FP_DISABLE}
+                   ${NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE}
                    ON
                    "${NUNAVUT_VERIFICATION_TARGET_ENDIANNESS}"
                    "never")
@@ -178,6 +184,7 @@ create_dsdl_target(dsdl-test
                    OFF
                    ${NUNAVUT_VERIFICATION_SER_ASSERT}
                    ${NUNAVUT_VERIFICATION_SER_FP_DISABLE}
+                   ${NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE}
                    ON
                    "${NUNAVUT_VERIFICATION_TARGET_ENDIANNESS}"
                    "never"

--- a/verification/CMakeLists.txt
+++ b/verification/CMakeLists.txt
@@ -50,8 +50,8 @@ if(NOT DEFINED NUNAVUT_VERIFICATION_SER_FP_DISABLE)
      set(NUNAVUT_VERIFICATION_SER_FP_DISABLE OFF CACHE BOOL "Enable or disable floating point support in generated support code.")
 endif()
 
-if(NOT DEFINED NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE)
-     set(NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE OFF CACHE BOOL "Enable or disable optional variable array capacity override in generated code.")
+if(NOT DEFINED NUNAVUT_VERIFICATION_OVR_VAR_ARRAY_ENABLE)
+     set(NUNAVUT_VERIFICATION_OVR_VAR_ARRAY_ENABLE OFF CACHE BOOL "Enable or disable override variable array capacity in generated support code.")
 endif()
 
 if (NUNAVUT_VERIFICATION_LANG STREQUAL "cpp")
@@ -152,7 +152,7 @@ create_dsdl_target(nunavut-support
                    OFF
                    ${NUNAVUT_VERIFICATION_SER_ASSERT}
                    ${NUNAVUT_VERIFICATION_SER_FP_DISABLE}
-                   ${NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE}
+                   ${NUNAVUT_VERIFICATION_OVR_VAR_ARRAY_ENABLE}
                    ON
                    "${NUNAVUT_VERIFICATION_TARGET_ENDIANNESS}"
                    "only")
@@ -167,7 +167,7 @@ create_dsdl_target(dsdl-regulated
                    OFF
                    ${NUNAVUT_VERIFICATION_SER_ASSERT}
                    ${NUNAVUT_VERIFICATION_SER_FP_DISABLE}
-                   ${NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE}
+                   ${NUNAVUT_VERIFICATION_OVR_VAR_ARRAY_ENABLE}
                    ON
                    "${NUNAVUT_VERIFICATION_TARGET_ENDIANNESS}"
                    "never")
@@ -184,7 +184,7 @@ create_dsdl_target(dsdl-test
                    OFF
                    ${NUNAVUT_VERIFICATION_SER_ASSERT}
                    ${NUNAVUT_VERIFICATION_SER_FP_DISABLE}
-                   ${NUNAVUT_OVERRIDE_VARIABLE_ARRAY_CAPACITY_ENABLE}
+                   ${NUNAVUT_VERIFICATION_OVR_VAR_ARRAY_ENABLE}
                    ON
                    "${NUNAVUT_VERIFICATION_TARGET_ENDIANNESS}"
                    "never"

--- a/verification/c/suite/test_override_variable_array_capacity.c
+++ b/verification/c/suite/test_override_variable_array_capacity.c
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 UAVCAN Development Team.
+// This software is distributed under the terms of the MIT License.
+
+
+#if NUNAVUT_SUPPORT_LANGUAGE_OPTION_ENABLE_OVERRIDE_VARIABLE_ARRAY_CAPACITY == 1
+#  define OVERRIDE_SIZE 2
+#  define regulated_basics_PrimitiveArrayVariable_0_1_a_u64_ARRAY_CAPACITY_ OVERRIDE_SIZE
+#  define regulated_basics_PrimitiveArrayVariable_0_1_n_f32_ARRAY_CAPACITY_ OVERRIDE_SIZE
+#endif
+
+#include <regulated/basics/PrimitiveArrayVariable_0_1.h>
+#include "unity.h"  // Include 3rd-party headers afterward to ensure that our headers are self-sufficient.
+#include <stdlib.h>
+#include <time.h>
+
+
+static void testPrimitiveArrayVariableOverride(void)
+{
+    regulated_basics_PrimitiveArrayVariable_0_1 ref;
+
+#if NUNAVUT_SUPPORT_LANGUAGE_OPTION_ENABLE_OVERRIDE_VARIABLE_ARRAY_CAPACITY == 1
+    TEST_ASSERT_EQUAL(sizeof(ref.a_u64.elements[0]) * OVERRIDE_SIZE, sizeof(ref.a_u64.elements));
+    TEST_ASSERT_EQUAL(sizeof(ref.n_f64.elements[0]) * OVERRIDE_SIZE, sizeof(ref.n_f64.elements));
+#else
+    TEST_ASSERT_EQUAL(sizeof(ref.a_u64.elements[0]) *
+                      regulated_basics_PrimitiveArrayVariable_0_1_a_u64_ARRAY_CAPACITY_,
+                      sizeof(ref.a_u64.elements));
+    TEST_ASSERT_EQUAL(sizeof(ref.n_f64.elements[0]) *
+                      regulated_basics_PrimitiveArrayVariable_0_1_n_f32_ARRAY_CAPACITY_,
+                      sizeof(ref.n_f64.elements));
+#endif
+}
+
+void setUp(void)
+{
+
+}
+
+void tearDown(void)
+{
+
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(testPrimitiveArrayVariableOverride);
+
+    return UNITY_END();
+}

--- a/verification/c/suite/test_override_variable_array_capacity.c
+++ b/verification/c/suite/test_override_variable_array_capacity.c
@@ -17,6 +17,7 @@
 static void testPrimitiveArrayVariableOverride(void)
 {
     regulated_basics_PrimitiveArrayVariable_0_1 ref;
+    uint8_t buf[regulated_basics_PrimitiveArrayVariable_0_1_SERIALIZATION_BUFFER_SIZE_BYTES_ - 1];
 
 #if NUNAVUT_SUPPORT_LANGUAGE_OPTION_ENABLE_OVERRIDE_VARIABLE_ARRAY_CAPACITY == 1
     TEST_ASSERT_EQUAL(sizeof(ref.a_u64.elements[0]) * OVERRIDE_SIZE, sizeof(ref.a_u64.elements));
@@ -28,6 +29,16 @@ static void testPrimitiveArrayVariableOverride(void)
     TEST_ASSERT_EQUAL(sizeof(ref.n_f64.elements[0]) *
                       regulated_basics_PrimitiveArrayVariable_0_1_n_f32_ARRAY_CAPACITY_,
                       sizeof(ref.n_f64.elements));
+#endif
+
+    size_t size = sizeof(buf);
+
+#if NUNAVUT_SUPPORT_LANGUAGE_OPTION_ENABLE_OVERRIDE_VARIABLE_ARRAY_CAPACITY == 1
+    TEST_ASSERT_EQUAL(NUNAVUT_SUCCESS,
+                      regulated_basics_PrimitiveArrayVariable_0_1_serialize_(&ref, &buf[0], &size));
+#else
+    TEST_ASSERT_EQUAL(-NUNAVUT_ERROR_SERIALIZATION_BUFFER_TOO_SMALL,
+                      regulated_basics_PrimitiveArrayVariable_0_1_serialize_(&ref, &buf[0], &size));
 #endif
 }
 

--- a/verification/cmake/modules/Findnnvg.cmake
+++ b/verification/cmake/modules/Findnnvg.cmake
@@ -18,9 +18,9 @@
 # :param Path ARG_DSDL_ROOT_DIR:            A directory containing the root namespace dsdl.
 # :param bool ARG_ENABLE_CLANG_FORMAT:      If ON then clang-format will be run on each generated file.
 # :param bool ARG_ENABLE_SER_ASSERT:        Generates code with serialization asserts enabled
-# :param bool ARG_ENABLE_OVR_VAR_ARRAY:     Generates code with variable array capacity override enabled
 # :param bool ARG_DISABLE_SER_FP:           Generates code with floating point support removed from
 #                                           serialization logic.
+# :param bool ARG_ENABLE_OVR_VAR_ARRAY:     Generates code with variable array capacity override enabled
 # :param bool ARG_ENABLE_EXPERIMENTAL:      If true then nnvg is invoked with support for experimental
 #                                           languages.
 # :param str ARG_SER_ENDIANNESS:            One of 'any', 'big', or 'little' to pass as the value of the
@@ -39,17 +39,17 @@ function (create_dsdl_target ARG_TARGET_NAME
                              ARG_DSDL_ROOT_DIR
                              ARG_ENABLE_CLANG_FORMAT
                              ARG_ENABLE_SER_ASSERT
-                             ARG_ENABLE_OVR_VAR_ARRAY
                              ARG_DISABLE_SER_FP
+                             ARG_ENABLE_OVR_VAR_ARRAY
                              ARG_ENABLE_EXPERIMENTAL
                              ARG_SER_ENDIANNESS
                              ARG_GENERATE_SUPPORT)
 
     separate_arguments(NNVG_CMD_ARGS UNIX_COMMAND "${NNVG_FLAGS}")
 
-    if (${ARGC} GREATER 10)
+    if (${ARGC} GREATER 11)
         MATH(EXPR ARG_N_LAST "${ARGC}-1")
-        foreach(ARG_N RANGE 10 ${ARG_N_LAST})
+        foreach(ARG_N RANGE 11 ${ARG_N_LAST})
             list(APPEND NNVG_CMD_ARGS "-I")
             list(APPEND NNVG_CMD_ARGS "${ARGV${ARG_N}}")
         endforeach(ARG_N)
@@ -74,14 +74,14 @@ function (create_dsdl_target ARG_TARGET_NAME
         message(STATUS "Enabling seralization asserts in generated code.")
     endif()
 
-    if (ARG_ENABLE_OVR_VAR_ARRAY)
-        list(APPEND NNVG_CMD_ARGS "--enable-override-variable-array-capacity")
-        message(STATUS "Enabling variable array capacity override option in generated code.")
-    endif()
-
     if (ARG_DISABLE_SER_FP)
         list(APPEND NNVG_CMD_ARGS "--omit-float-serialization-support")
         message(STATUS "Disabling floating point seralization routines in generated support code.")
+    endif()
+
+    if (ARG_ENABLE_OVR_VAR_ARRAY)
+        list(APPEND NNVG_CMD_ARGS "--enable-override-variable-array-capacity")
+        message(STATUS "Enabling variable array capacity override option in generated code.")
     endif()
 
     if (ARG_ENABLE_EXPERIMENTAL)

--- a/verification/cmake/modules/Findnnvg.cmake
+++ b/verification/cmake/modules/Findnnvg.cmake
@@ -18,6 +18,7 @@
 # :param Path ARG_DSDL_ROOT_DIR:            A directory containing the root namespace dsdl.
 # :param bool ARG_ENABLE_CLANG_FORMAT:      If ON then clang-format will be run on each generated file.
 # :param bool ARG_ENABLE_SER_ASSERT:        Generates code with serialization asserts enabled
+# :param bool ARG_ENABLE_OVR_VAR_ARRAY:     Generates code with variable array capacity override enabled
 # :param bool ARG_DISABLE_SER_FP:           Generates code with floating point support removed from
 #                                           serialization logic.
 # :param bool ARG_ENABLE_EXPERIMENTAL:      If true then nnvg is invoked with support for experimental
@@ -38,6 +39,7 @@ function (create_dsdl_target ARG_TARGET_NAME
                              ARG_DSDL_ROOT_DIR
                              ARG_ENABLE_CLANG_FORMAT
                              ARG_ENABLE_SER_ASSERT
+                             ARG_ENABLE_OVR_VAR_ARRAY
                              ARG_DISABLE_SER_FP
                              ARG_ENABLE_EXPERIMENTAL
                              ARG_SER_ENDIANNESS
@@ -70,6 +72,11 @@ function (create_dsdl_target ARG_TARGET_NAME
     if (ARG_ENABLE_SER_ASSERT)
         list(APPEND NNVG_CMD_ARGS "--enable-serialization-asserts")
         message(STATUS "Enabling seralization asserts in generated code.")
+    endif()
+
+    if (ARG_ENABLE_OVR_VAR_ARRAY)
+        list(APPEND NNVG_CMD_ARGS "--enable-override-variable-array-capacity")
+        message(STATUS "Enabling variable array capacity override option in generated code.")
     endif()
 
     if (ARG_DISABLE_SER_FP)


### PR DESCRIPTION
Allow override ARRAY_CAPACITY in variable array to optimize publisher memory usage at compile time.

As a publisher you might already know the maximum size of variable length array. This commit allow to override the XXXX_ARRAY_CAPACITY_ define for variable length arrays.

A good example would be the reg_drone_service_battery_Status_0_2_cell_voltages_ARRAY_CAPACITY_ define. At default the maximum is 255, but for instance your BMS only supports atmost 6 cells.

By default the reg.drone.service.battery.Status_0.2 struct is 1056 bytes
```
hovergames@hovergames:~/uavcan/nunavut_redefine_test$ ./nunavut_redefine_test 
Size of reg_drone_service_battery_Status_0_2 1056
```

By allowing to overrule the cell_voltages array capacity we can decrease the struct size tremendously.

```
#include <stdio.h>

#define reg_drone_service_battery_Status_0_2_cell_voltages_ARRAY_CAPACITY_ 6

#include "inc/UAVCAN/reg/drone/service/battery/Status_0_2.h"

int main(int argc, char *argv[]) {
    reg_drone_service_battery_Status_0_2 msg;
    printf("Size of reg_drone_service_battery_Status_0_2 %li\n", sizeof(msg));
}
```

We only need 56 bytes now to allocate this struct on our stack

```
hovergames@hovergames:~/uavcan/nunavut_redefine_test$ ./nunavut_redefine_test 
Size of reg_drone_service_battery_Status_0_2 56
```