### PR TITLE
Fix JS/CSS Asset Include into Nunavut

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,4 @@ with open('src/nunavut/version.py') as fp:
     exec(fp.read(), version)
 
 setuptools.setup(version=version['__version__'],
-                 package_data={'': ['*.j2', '*.ini', '*.hpp', '*.h']})
+                 package_data={'': ['*.j2', '**/*.css', '**/*.js', '*.ini', '*.hpp', '*.h']})


### PR DESCRIPTION
Previously, JS and CSS assets in the HTML template directory would not be included in the built package, causing HTML documentation generation to fail. This PR fixes this issue by including JS and CSS assets via setup.py package_data.