### PR TITLE
C++ language implementation (first steps)

### DIFF
--- a/src/nunavut/lang/c/__init__.py
+++ b/src/nunavut/lang/c/__init__.py
@@ -837,11 +837,17 @@ def filter_literal(
     language: Language,
     value: typing.Union[fractions.Fraction, bool, int],
     ty: pydsdl.Any,
-    cast_format: str = "(({type}) {value})",
+    cast_format: typing.Optional[str] = None,
 ) -> str:
     """
     Renders the specified value of the specified type as a literal.
     """
+    if cast_format is None:
+        maybe_cast_format = language.get_option("cast_format")
+        if not isinstance(maybe_cast_format, str):
+            raise RuntimeError("cast_format language option was missing or invalid.")
+        cast_format = maybe_cast_format
+        del maybe_cast_format
     if isinstance(ty, pydsdl.BooleanType):
         return str(language.valuetoken_true if value else language.valuetoken_false)
 

--- a/src/nunavut/lang/cpp/__init__.py
+++ b/src/nunavut/lang/cpp/__init__.py
@@ -161,7 +161,7 @@ def filter_constant_value(language: Language, constant: pydsdl.Constant) -> str:
     """
     Renders the specified value of the specified type as a literal.
     """
-    return c_filter_literal(language, constant.value.native_value, constant.data_type, "static_cast<{type}>({value})")
+    return c_filter_literal(language, constant.value.native_value, constant.data_type)
 
 
 @template_language_filter(__name__)
@@ -169,7 +169,7 @@ def filter_literal(
     language: Language,
     value: typing.Union[fractions.Fraction, bool, int],
     ty: pydsdl.Any,
-    cast_format: str = "static_cast<{type}>({value})",
+    cast_format: typing.Optional[str] = None,
 ) -> str:
     """
     Renders the specified value of the specified type as a literal.

--- a/src/nunavut/lang/cpp/__init__.py
+++ b/src/nunavut/lang/cpp/__init__.py
@@ -9,6 +9,7 @@
 """
 
 import functools
+import fractions
 import io
 import re
 import textwrap
@@ -161,6 +162,19 @@ def filter_constant_value(language: Language, constant: pydsdl.Constant) -> str:
     Renders the specified value of the specified type as a literal.
     """
     return c_filter_literal(language, constant.value.native_value, constant.data_type, "static_cast<{type}>({value})")
+
+
+@template_language_filter(__name__)
+def filter_literal(
+    language: Language,
+    value: typing.Union[fractions.Fraction, bool, int],
+    ty: pydsdl.Any,
+    cast_format: str = "static_cast<{type}>({value})",
+) -> str:
+    """
+    Renders the specified value of the specified type as a literal.
+    """
+    return c_filter_literal(language, value, ty, cast_format)
 
 
 def filter_to_standard_bit_length(t: pydsdl.PrimitiveType) -> int:

--- a/src/nunavut/lang/cpp/__init__.py
+++ b/src/nunavut/lang/cpp/__init__.py
@@ -531,6 +531,27 @@ def filter_short_reference_name(language: Language, t: pydsdl.CompositeType) -> 
         my_type.version = MagicMock()
         my_type.parent_service = None
 
+    .. code-block:: python
+
+        # Given a type with illegal C++ characters
+        my_type.short_name = 'Struct_'
+        my_type.version.major = 0
+        my_type.version.minor = 1
+
+        # and
+        template = '{{ my_type | short_reference_name }}'
+
+        # then, with stropping enabled
+        rendered = 'Struct__0_1'
+
+    .. invisible-code-block: python
+
+        jinja_filter_tester(filter_short_reference_name, template, rendered, 'cpp', my_type=my_type)
+
+        my_type = MagicMock(spec=pydsdl.StructureType)
+        my_type.version = MagicMock()
+        my_type.parent_service = None
+
     :param pydsdl.CompositeType t: The DSDL type to get the reference name for.
     """
     return language.filter_short_reference_name(t)

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -227,8 +227,8 @@ public:
 } // namespace detail
 
 struct bitspan: public detail::any_bitspan<bitspan>{
-    friend class detail::any_bitspan<bitspan>;
-    friend class const_bitspan;
+    friend struct detail::any_bitspan<bitspan>;
+    friend struct const_bitspan;
 private:
     bytespan data_;
     {{ typename_unsigned_bit_length }} offset_bits_;
@@ -263,7 +263,7 @@ public:
 };
 
 struct const_bitspan: public detail::any_bitspan<const_bitspan>{
-    friend class detail::any_bitspan<const_bitspan>;
+    friend struct detail::any_bitspan<const_bitspan>;
 private:
     const_bytespan data_;
     {{ typename_unsigned_bit_length }} offset_bits_;

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -140,15 +140,6 @@ public:
         return derived_bitspan(self.data_, self.offset_bits_ + bits);
     }
 
-    derived_bitspan subspan({{ typename_unsigned_bit_length }} bits_at=0) const noexcept {
-        auto& self  = *static_cast<const derived_bitspan*>(this);
-        const {{ typename_unsigned_bit_length }} offset_bits = self.offset_bits_ + bits_at;
-        const {{ typename_unsigned_length }} offset_bytes = offset_bits / 8U;
-        {{ assert('offset_bytes * 8U <= offset_bits') }}
-        const {{ typename_unsigned_length }} new_offset_bits = offset_bits - offset_bytes * 8U;
-        {{ assert('offset_bytes <= self.data_.size()') }}
-        return derived_bitspan({ self.data_.data() + offset_bytes, self.data_.size() - offset_bytes}, new_offset_bits);
-    }
 
     void add_offset({{ typename_unsigned_bit_length }} bits) noexcept{
         auto& self  = *static_cast<derived_bitspan*>(this);
@@ -236,6 +227,9 @@ public:
     bitspan(bytespan data, {{ typename_unsigned_bit_length }} offset_bits=0)
         :data_(std::move(data)), offset_bits_(offset_bits){
     }
+
+    Result<bitspan> subspan({# -#}
+        {{ typename_unsigned_bit_length }} bits_at, {{ typename_unsigned_bit_length }} size_bits) const noexcept;
     // ---------------------------------------------------- INTEGER ----------------------------------------------------
     /// Serialize a DSDL field value at the specified bit offset from the beginning of the destination buffer.
     /// The behavior is undefined if the input pointer is nullprt. The time complexity is linear of the bit length.
@@ -271,6 +265,8 @@ public:
     const_bitspan(const_bytespan data, {{ typename_unsigned_bit_length }} offset_bits=0)
         :data_(std::move(data)), offset_bits_(offset_bits){
     }
+
+
     /// Copy the specified number of bits from the source buffer into the destination buffer in accordance with the
     /// DSDL bit-level serialization specification. The offsets may be arbitrary (may exceed 8 bits).
     /// If both offsets are byte-aligned, the function invokes memmove() and possibly adjusts the last byte separately.
@@ -472,6 +468,25 @@ VoidResult bitspan::padAndMoveToAlignment({{ typename_unsigned_bit_length }} n_b
         {{ assert('offset_alings_to(n_bits)') }}
     }
     return {};
+}
+
+
+Result<bitspan> bitspan::subspan({# -#}
+        {{ typename_unsigned_bit_length }} bits_at, {{ typename_unsigned_bit_length }} size_bits) const noexcept {
+    const {{ typename_unsigned_bit_length }} offset_bits = offset_bits_ + bits_at;
+    const {{ typename_unsigned_length }} offset_bytes = offset_bits / 8U;
+    const {{ typename_unsigned_length }} new_offset_bits = offset_bits % 8U;
+    {{ assert('offset_bytes * 8U <= offset_bits') }}
+    if(offset_bytes > data_.size()){
+        return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
+    }
+    const {{ typename_unsigned_length }} new_size_bits = new_offset_bits + size_bits;
+    const {{ typename_unsigned_length }} size_available_bits = (data_.size() - offset_bytes) * 8U;
+    if(new_size_bits > size_available_bits){
+        return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
+    }
+    const {{ typename_unsigned_length }} new_size_bytes = new_size_bits / 8U;
+    return bitspan({ data_.data() + offset_bytes, new_size_bytes }, new_offset_bits);
 }
 
 

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -61,8 +61,6 @@ static_assert(__cplusplus >= 201100L,
 #include <cmath>  // For isfinite().
 {% endif -%}
 #include <cstdint>
-#include "span_lite.hpp"
-#include "tl_expected.hpp"
 #ifdef __cpp_lib_bit_cast
 #include <bit>
 #endif // def __cpp_lib_bit_cast
@@ -84,10 +82,6 @@ using std::bitcast;
 #else // def __cpp_lib_bit_cast
 
 #endif // def __cpp_lib_bit_cast
-
-#ifdef NUNAVUT_USE_SPAN_LITE
-using nonstd::span;
-#else
 
 template<typename T>
 class span{
@@ -115,14 +109,9 @@ public:
     }
 };
 
-#endif
 using bytespan = span<{{ typename_byte }}> ;
 using const_bytespan = span<const {{ typename_byte }}> ;
 
-
-#if span_FEATURE( MAKE_SPAN )
-using nonstd::make_span;
-#endif  // span_FEATURE( MAKE_SPAN )
 
 
 /// Nunavut serialization will never define more than 127 errors and the reserved error numbers are [1,127]
@@ -137,16 +126,10 @@ enum class Error{
     REPRESENTATION_BAD_DELIMITER_HEADER=12
 };
 
-#ifdef NUNAVUT_USE_TL_EXPECTED
-template<typename Err>
-using unexpected = tl::unexpected<Err>;
-template<typename Ret>
-using Result = tl::expected<Ret, Error>;
-#else
+
 template<typename Err>
 struct unexpected{
     Err value;
-
     explicit unexpected(Err e):value(e){}
 };
 
@@ -212,8 +195,6 @@ public:
 
 template<typename Ret>
 using Result = expected<Ret>;
-#endif
-
 
 using VoidResult = Result<void>;
 using SerializeResult = Result<{{ typename_unsigned_length }}>;

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -490,6 +490,7 @@ Result<bitspan> bitspan::subspan({# -#}
 }
 
 
+
 uint8_t const_bitspan::getU8(const uint8_t len_bits) const noexcept
 {
     {{ assert('data_.data() != nullptr') }}

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -12,6 +12,14 @@
     {%- endif -%}
 {%- endmacro -%}
 
+{%- macro float32_union() -%}
+    typedef union  // NOSONAR
+    {
+        uint32_t bits;
+        {{typename_float_32}} real;
+    } Float32Bits;
+{%- endmacro -%}
+
 // UAVCAN common serialization support routines.                                                             +-+ +-+
 // This file is based on canard_dsdl.h, which is part of Libcanard.                                          | | | |
 //                                                                                                           \  -  /
@@ -29,6 +37,25 @@
 static_assert(__cplusplus >= 201100L,
               "Unsupported language: ISO C11, C++11, or a newer version of either is required.");
 
+
+{% if not options.omit_float_serialization_support -%}
+/// Detect whether the target platform is compatible with IEEE 754.
+#define NUNAVUT_PLATFORM_IEEE754_FLOAT \
+    ((FLT_RADIX == 2) && (FLT_MANT_DIG == 24) && (FLT_MIN_EXP == -125) && (FLT_MAX_EXP == 128))
+#define NUNAVUT_PLATFORM_IEEE754_DOUBLE \
+    ((FLT_RADIX == 2) && (DBL_MANT_DIG == 53) && (DBL_MIN_EXP == -1021) && (DBL_MAX_EXP == 1024))
+{% endif -%}
+
+{%- if options.enable_serialization_asserts %}
+#ifndef NUNAVUT_ASSERT
+// By default Nunavut does not generate assert statements since the logic to halt a program is platform
+// dependent and because this header requires an absolute minimum from a platform and from the C standard library.
+// Most platforms can simply define "NUNAVUT_ASSERT(x)=assert(x)" (<assert.h> is always included by Nunavut).
+#   error "You must either define NUNAVUT_ASSERT or you need to disable assertions" \
+          " when generating serialization support code using Nunavut language options"
+#endif
+{% endif -%}
+
 #include <cstring> // for std::size_t
 {% if not options.omit_float_serialization_support %}
 #include <cmath>  // For isfinite().
@@ -36,6 +63,9 @@ static_assert(__cplusplus >= 201100L,
 #include <cstdint>
 #include "span_lite.hpp"
 #include "tl_expected.hpp"
+#ifdef __cpp_lib_bit_cast
+#include <bit>
+#endif // def __cpp_lib_bit_cast
 
 static_assert(sizeof({{ typename_unsigned_bit_length }}) >= sizeof({{ typename_unsigned_length }}),
     "The bit-length type used by Nunavut, {{ typename_unsigned_bit_length }}, "
@@ -48,6 +78,13 @@ namespace nunavut
 {
 namespace support
 {
+
+#ifdef __cpp_lib_bit_cast
+using std::bitcast;
+#else // def __cpp_lib_bit_cast
+
+#endif // def __cpp_lib_bit_cast
+
 
 using nonstd::span;
 using bytespan = span<{{ typename_byte }}> ;
@@ -171,6 +208,12 @@ public:
     VoidResult setUxx(const uint64_t value, const uint8_t len_bits);
 
     VoidResult setIxx(const int64_t value, const uint8_t len_bits);
+
+    VoidResult setF16(const {{ typename_float_32 }} value);
+
+    VoidResult setF32(const {{ typename_float_32 }} value);
+
+    VoidResult setF64(const {{ typename_float_64 }} value);
 };
 
 struct const_bitspan: public detail::any_bitspan<const_bitspan>{
@@ -321,113 +364,135 @@ public:
         return 1U == getU8(1U);
     }
 
-    uint8_t getU8(const uint8_t len_bits) const noexcept
-    {
-        {{ assert('data_.data() != nullptr') }}
-        const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 8U));
-        {{ assert('bits <= (sizeof(uint8_t) * 8U)') }}
-        uint8_t val = 0;
-        copyTo(bitspan{ { &val, 1U } }, bits);
-        return val;
-    }
+    uint8_t getU8(const uint8_t len_bits) const noexcept;
 
-    uint16_t getU16(const uint8_t len_bits) const noexcept
-    {
-        {{ assert('data_.data() != nullptr') }}
-        const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 16U));
-        {{ assert('bits <= (sizeof(uint16_t) * 8U)') }}
-    {%- if options.target_endianness == 'little' %}
-        uint16_t val = 0U;
-        copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
-        return val;
-    {%- elif options.target_endianness in ('any', 'big') %}
-        uint8_t tmp[sizeof(uint16_t)] = {0};
-        copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
-        return static_cast<uint16_t>(static_cast<uint16_t>(tmp[0]) | ((static_cast<uint16_t>(tmp[1])) << 8U));
-    {%- else %}{%- assert False %}
-    {%- endif %}
-    }
+    uint16_t getU16(const uint8_t len_bits) const noexcept;
 
-    uint32_t getU32(const uint8_t len_bits) const noexcept
-    {
-        {{ assert('data_.data() != nullptr') }}
-        const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 32U));
-        {{ assert('bits <= (sizeof(uint32_t) * 8U)') }}
-    {%- if options.target_endianness == 'little' %}
-        uint32_t val = 0U;
-        copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
-        return val;
-    {%- elif options.target_endianness in ('any', 'big') %}
-        uint8_t tmp[sizeof(uint32_t)] = {0};
-        copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
-        return static_cast<uint32_t>(static_cast<uint32_t>(tmp[0]) |
-                        (static_cast<uint32_t>(tmp[1]) << 8U) |
-                        (static_cast<uint32_t>(tmp[2]) << 16U) |
-                        (static_cast<uint32_t>(tmp[3]) << 24U));
-    {%- else %}{%- assert False %}
-    {%- endif %}
-    }
+    uint32_t getU32(const uint8_t len_bits) const noexcept;
 
-    uint64_t getU64(const uint8_t len_bits) const noexcept
-    {
-        {{ assert('data_.data() != nullptr') }}
-        const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 64U));
-        {{ assert('bits <= (sizeof(uint64_t) * 8U)') }}
-    {%- if options.target_endianness == 'little' %}
-        uint64_t val = 0U;
-        copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
-        return val;
-    {%- elif options.target_endianness in ('any', 'big') %}
-        uint8_t tmp[sizeof(uint64_t)] = {0};
-        copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
-        return static_cast<uint64_t>(static_cast<uint64_t>(tmp[0]) |
-                        (static_cast<uint64_t>(tmp[1]) << 8U) |
-                        (static_cast<uint64_t>(tmp[2]) << 16U) |
-                        (static_cast<uint64_t>(tmp[3]) << 24U) |
-                        (static_cast<uint64_t>(tmp[4]) << 32U) |
-                        (static_cast<uint64_t>(tmp[5]) << 40U) |
-                        (static_cast<uint64_t>(tmp[6]) << 48U) |
-                        (static_cast<uint64_t>(tmp[7]) << 56U));
-    {%- else %}{%- assert False %}
-    {%- endif %}
-    }
+    uint64_t getU64(const uint8_t len_bits) const noexcept;
 
-    int8_t getI8(const uint8_t len_bits) const noexcept
-    {
-        const uint8_t sat = std::min<uint8_t>(len_bits, 8U);
-        uint8_t       val = getU8(sat);
-        const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-        val = ((sat < 8U) && neg) ? static_cast<uint8_t>(val | ~((1U << sat) - 1U)) : val;  // Sign extension
-        return neg ? static_cast<int8_t>(-static_cast<int8_t>(static_cast<uint8_t>(~val)) - 1) : static_cast<int8_t>(val);
-    }
+    int8_t getI8(const uint8_t len_bits) const noexcept;
 
-    int16_t getI16(const uint8_t len_bits) const noexcept
-    {
-        const uint8_t sat = std::min<uint8_t>(len_bits, 16U);
-        uint16_t      val = getU16(sat);
-        const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-        val = ((sat < 16U) && neg) ? static_cast<uint16_t>(val | ~((1U << sat) - 1U)) : val;  // Sign extension
-        return neg ? static_cast<int16_t>(-static_cast<int16_t>(static_cast<uint16_t>(~val)) - 1) : static_cast<int16_t>(val);
-    }
+    int16_t getI16(const uint8_t len_bits) const noexcept;
 
-    int32_t getI32(const uint8_t len_bits) const noexcept
-    {
-        const uint8_t sat = std::min<uint8_t>(len_bits, 32U);
-        uint32_t      val = getU32(sat);
-        const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-        val = ((sat < 32U) && neg) ? static_cast<uint32_t>(val | ~((1UL << sat) - 1U)) : val;  // Sign extension
-        return neg ? static_cast<int32_t>((-static_cast<int32_t>(~val)) - 1) : static_cast<int32_t>(val);
-    }
+    int32_t getI32(const uint8_t len_bits) const noexcept;
 
-    int64_t getI64(const uint8_t len_bits) const noexcept
-    {
-        const uint8_t sat = std::min<uint8_t>(len_bits, 64U);
-        uint64_t      val = getU64(sat);
-        const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-        val = ((sat < 64U) && neg) ? static_cast<uint64_t>(val | ~((1ULL << sat) - 1U)) : val;  // Sign extension
-        return neg ? static_cast<int64_t>((-static_cast<int64_t>(~val)) - 1) : static_cast<int64_t>(val);
-    }
+    int64_t getI64(const uint8_t len_bits) const noexcept;
+
+    {{ typename_float_32 }} getF16();
+
+    {{ typename_float_32 }} getF32();
+
+    {{ typename_float_64 }} getF64();
 };
+
+uint8_t const_bitspan::getU8(const uint8_t len_bits) const noexcept
+{
+    {{ assert('data_.data() != nullptr') }}
+    const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 8U));
+    {{ assert('bits <= (sizeof(uint8_t) * 8U)') }}
+    uint8_t val = 0;
+    copyTo(bitspan{ { &val, 1U } }, bits);
+    return val;
+}
+
+uint16_t const_bitspan::getU16(const uint8_t len_bits) const noexcept
+{
+    {{ assert('data_.data() != nullptr') }}
+    const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 16U));
+    {{ assert('bits <= (sizeof(uint16_t) * 8U)') }}
+{%- if options.target_endianness == 'little' %}
+    uint16_t val = 0U;
+    copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
+    return val;
+{%- elif options.target_endianness in ('any', 'big') %}
+    uint8_t tmp[sizeof(uint16_t)] = {0};
+    copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
+    return static_cast<uint16_t>(static_cast<uint16_t>(tmp[0]) | ((static_cast<uint16_t>(tmp[1])) << 8U));
+{%- else %}{%- assert False %}
+{%- endif %}
+}
+
+uint32_t const_bitspan::getU32(const uint8_t len_bits) const noexcept
+{
+    {{ assert('data_.data() != nullptr') }}
+    const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 32U));
+    {{ assert('bits <= (sizeof(uint32_t) * 8U)') }}
+{%- if options.target_endianness == 'little' %}
+    uint32_t val = 0U;
+    copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
+    return val;
+{%- elif options.target_endianness in ('any', 'big') %}
+    uint8_t tmp[sizeof(uint32_t)] = {0};
+    copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
+    return static_cast<uint32_t>(static_cast<uint32_t>(tmp[0]) |
+                    (static_cast<uint32_t>(tmp[1]) << 8U) |
+                    (static_cast<uint32_t>(tmp[2]) << 16U) |
+                    (static_cast<uint32_t>(tmp[3]) << 24U));
+{%- else %}{%- assert False %}
+{%- endif %}
+}
+
+uint64_t const_bitspan::getU64(const uint8_t len_bits) const noexcept
+{
+    {{ assert('data_.data() != nullptr') }}
+    const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 64U));
+    {{ assert('bits <= (sizeof(uint64_t) * 8U)') }}
+{%- if options.target_endianness == 'little' %}
+    uint64_t val = 0U;
+    copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
+    return val;
+{%- elif options.target_endianness in ('any', 'big') %}
+    uint8_t tmp[sizeof(uint64_t)] = {0};
+    copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
+    return static_cast<uint64_t>(static_cast<uint64_t>(tmp[0]) |
+                    (static_cast<uint64_t>(tmp[1]) << 8U) |
+                    (static_cast<uint64_t>(tmp[2]) << 16U) |
+                    (static_cast<uint64_t>(tmp[3]) << 24U) |
+                    (static_cast<uint64_t>(tmp[4]) << 32U) |
+                    (static_cast<uint64_t>(tmp[5]) << 40U) |
+                    (static_cast<uint64_t>(tmp[6]) << 48U) |
+                    (static_cast<uint64_t>(tmp[7]) << 56U));
+{%- else %}{%- assert False %}
+{%- endif %}
+}
+
+int8_t const_bitspan::getI8(const uint8_t len_bits) const noexcept
+{
+    const uint8_t sat = std::min<uint8_t>(len_bits, 8U);
+    uint8_t       val = getU8(sat);
+    const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
+    val = ((sat < 8U) && neg) ? static_cast<uint8_t>(val | ~((1U << sat) - 1U)) : val;  // Sign extension
+    return neg ? static_cast<int8_t>(-static_cast<int8_t>(static_cast<uint8_t>(~val)) - 1) : static_cast<int8_t>(val);
+}
+
+int16_t const_bitspan::getI16(const uint8_t len_bits) const noexcept
+{
+    const uint8_t sat = std::min<uint8_t>(len_bits, 16U);
+    uint16_t      val = getU16(sat);
+    const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
+    val = ((sat < 16U) && neg) ? static_cast<uint16_t>(val | ~((1U << sat) - 1U)) : val;  // Sign extension
+    return neg ? static_cast<int16_t>(-static_cast<int16_t>(static_cast<uint16_t>(~val)) - 1) : static_cast<int16_t>(val);
+}
+
+int32_t const_bitspan::getI32(const uint8_t len_bits) const noexcept
+{
+    const uint8_t sat = std::min<uint8_t>(len_bits, 32U);
+    uint32_t      val = getU32(sat);
+    const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
+    val = ((sat < 32U) && neg) ? static_cast<uint32_t>(val | ~((1UL << sat) - 1U)) : val;  // Sign extension
+    return neg ? static_cast<int32_t>((-static_cast<int32_t>(~val)) - 1) : static_cast<int32_t>(val);
+}
+
+int64_t const_bitspan::getI64(const uint8_t len_bits) const noexcept
+{
+    const uint8_t sat = std::min<uint8_t>(len_bits, 64U);
+    uint64_t      val = getU64(sat);
+    const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
+    val = ((sat < 64U) && neg) ? static_cast<uint64_t>(val | ~((1ULL << sat) - 1U)) : val;  // Sign extension
+    return neg ? static_cast<int64_t>((-static_cast<int64_t>(~val)) - 1) : static_cast<int64_t>(val);
+}
 
 VoidResult bitspan::setBit(const bool value)
 {
@@ -477,6 +542,155 @@ VoidResult bitspan::setIxx(const int64_t value, const uint8_t len_bits)
     // is no change in the bit pattern (if there is no truncation). ]
     return setUxx(static_cast<uint64_t>(value), len_bits);
 }
+
+
+{%- if not options.omit_float_serialization_support %}
+
+// ---------------------------------------------------- FLOAT16 ----------------------------------------------------
+
+static_assert(NUNAVUT_PLATFORM_IEEE754_FLOAT,
+              "The target platform does not support IEEE754 floating point operations.");
+static_assert(32U == (sizeof({{typename_float_32}}) * 8U), "Unsupported floating point model");
+
+/// Converts a single-precision float into the binary representation of the value as a half-precision IEEE754 value.
+static inline uint16_t float16Pack(const {{typename_float_32}} value)
+{
+    {{ float32_union() }}
+
+    // The no-lint statements suppress the warning about the use of union. This is required for low-level bit access.
+    const uint32_t round_mask = ~static_cast<uint32_t>(0x0FFFU);
+    Float32Bits    f32inf;  // NOSONAR
+    Float32Bits    f16inf;  // NOSONAR
+    Float32Bits    magic;   // NOSONAR
+    Float32Bits    in;      // NOSONAR
+    f32inf.bits = static_cast<uint32_t>( 255U) << 23U;
+    f16inf.bits = static_cast<uint32_t>( 31U) << 23U;
+    magic.bits = static_cast<uint32_t>( 15U) << 23U;
+    in.real = value;
+    const uint32_t sign = in.bits & (static_cast<uint32_t>( 1U) << 31U);
+    in.bits ^= sign;
+    uint16_t out = 0;
+    if (in.bits >= f32inf.bits)
+    {
+        if ((in.bits & 0x7FFFFFUL) != 0)
+        {
+            out = 0x7E00U;
+        }
+        else
+        {
+            out = (in.bits > f32inf.bits) ? static_cast<uint16_t>(0x7FFFU) : static_cast<uint16_t>(0x7C00U);
+        }
+    }
+    else
+    {
+        in.bits &= round_mask;
+        in.real *= magic.real;
+        in.bits -= round_mask;
+        if (in.bits > f16inf.bits)
+        {
+            in.bits = f16inf.bits;
+        }
+        out = static_cast<uint16_t>(in.bits >> 13U);
+    }
+    out |= static_cast<uint16_t>(sign >> 16U);
+    return out;
+}
+
+static inline {{typename_float_32}} float16Unpack(const uint16_t value)
+{
+    {{ float32_union() }}
+
+    // The no-lint statements suppress the warning about the use of union. This is required for low-level bit access.
+    Float32Bits magic;    // NOSONAR
+    Float32Bits inf_nan;  // NOSONAR
+    Float32Bits out;      // NOSONAR
+    magic.bits = static_cast<uint32_t>( 0xEFU) << 23U;
+    inf_nan.bits = static_cast<uint32_t>( 0x8FU) << 23U;
+    out.bits = static_cast<uint32_t>(value & 0x7FFFU) << 13U;
+    out.real *= magic.real;
+    if (out.real >= inf_nan.real)
+    {
+        out.bits |= static_cast<uint32_t>( 0xFFU) << 23U;
+    }
+    out.bits |= static_cast<uint32_t>(value & 0x8000U) << 16U;
+    return out.real;
+}
+
+VoidResult bitspan::setF16(const {{ typename_float_32 }} value)
+{
+    return setUxx(float16Pack(value), 16U);
+}
+
+{{typename_float_32}} const_bitspan::getF16()
+{
+    return float16Unpack(getU16(16U));
+}
+
+// ---------------------------------------------------- FLOAT32 ----------------------------------------------------
+
+static_assert(NUNAVUT_PLATFORM_IEEE754_FLOAT,
+              "The target platform does not support IEEE754 floating point operations.");
+static_assert(32U == (sizeof({{typename_float_32}}) * 8U), "Unsupported floating point model");
+
+VoidResult bitspan::setF32(const {{ typename_float_32 }} value)
+{
+    // Intentional violation of MISRA: use union to perform fast conversion from an IEEE 754-compatible native
+    // representation into a serializable integer. The assumptions about the target platform properties are made
+    // clear. In the future we may add a more generic conversion that is platform-invariant.
+    union  // NOSONAR
+    {
+        {{typename_float_32}} fl;
+        uint32_t in;
+    } const tmp = {value};  // NOSONAR
+    return setUxx(tmp.in, sizeof(tmp) * 8U);
+}
+
+{{typename_float_32}} const_bitspan::getF32()
+{
+    // Intentional violation of MISRA: use union to perform fast conversion to an IEEE 754-compatible native
+    // representation into a serializable integer. The assumptions about the target platform properties are made
+    // clear. In the future we may add a more generic conversion that is platform-invariant.
+    union  // NOSONAR
+    {
+        uint32_t in;
+        {{typename_float_32}} fl;
+    } const tmp = {getU32(32U)};
+    return tmp.fl;
+}
+
+// ---------------------------------------------------- FLOAT64 ----------------------------------------------------
+
+static_assert(NUNAVUT_PLATFORM_IEEE754_DOUBLE,
+              "The target platform does not support IEEE754 double-precision floating point operations.");
+static_assert(64U == (sizeof({{typename_float_64}}) * 8U), "Unsupported floating point model");
+
+VoidResult bitspan::setF64(const {{typename_float_64 }} value)
+{
+    // Intentional violation of MISRA: use union to perform fast conversion from an IEEE 754-compatible native
+    // representation into a serializable integer. The assumptions about the target platform properties are made
+    // clear. In the future we may add a more generic conversion that is platform-invariant.
+    union  // NOSONAR
+    {
+        {{typename_float_64}} fl;
+        uint64_t in;
+    } const tmp = {value};  // NOSONAR
+    return setUxx(tmp.in, sizeof(tmp) * 8U);
+}
+
+{{typename_float_64}} const_bitspan::getF64()
+{
+    // Intentional violation of MISRA: use union to perform fast conversion to an IEEE 754-compatible native
+    // representation into a serializable integer. The assumptions about the target platform properties are made
+    // clear. In the future we may add a more generic conversion that is platform-invariant.
+    union  // NOSONAR
+    {
+        uint64_t in;
+        {{typename_float_64}} fl;
+    } const tmp = {getU64(64U)};
+    return tmp.fl;
+}
+
+{% endif -%}
 
 
 } // end namespace support

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -85,10 +85,41 @@ using std::bitcast;
 
 #endif // def __cpp_lib_bit_cast
 
-
+#ifdef NUNAVUT_USE_SPAN_LITE
 using nonstd::span;
+#else
+
+template<typename T>
+class span{
+    T* ptr_;
+    {{ typename_unsigned_length }} size_;
+public:
+    template<{{ typename_unsigned_length }} N>
+    span(std::array<T, N>& data): ptr_(data.data()), size_(data.size()){}
+    template<{{ typename_unsigned_length }} N>
+    span(const std::array<T, N>& data): ptr_(data.data()), size_(data.size()){}
+    template<{{ typename_unsigned_length }} N>
+    span(T (&data)[N]): ptr_(data), size_(N){}
+    span(T* ptr,  {{ typename_unsigned_length }} size): ptr_(ptr), size_(size){}
+
+    T* data(){ return ptr_;}
+    T* data() const { return ptr_;}
+    {{ typename_unsigned_length }} size() const{ return size_; }
+    T& operator[]({{ typename_unsigned_length }} index){
+        {{ assert('index < size_') }}
+        return ptr_[index];
+    }
+    T& operator[]({{ typename_unsigned_length }} index) const {
+        {{ assert('index < size_') }}
+        return ptr_[index];
+    }
+};
+
+#endif
 using bytespan = span<{{ typename_byte }}> ;
 using const_bytespan = span<const {{ typename_byte }}> ;
+
+
 #if span_FEATURE( MAKE_SPAN )
 using nonstd::make_span;
 #endif  // span_FEATURE( MAKE_SPAN )
@@ -106,14 +137,90 @@ enum class Error{
     REPRESENTATION_BAD_DELIMITER_HEADER=12
 };
 
-inline tl::unexpected<Error> operator-(const Error& e){
-    return tl::unexpected<Error>{e};
-}
-
+#ifdef NUNAVUT_USE_TL_EXPECTED
+template<typename Err>
+using unexpected = tl::unexpected<Err>;
 template<typename Ret>
 using Result = tl::expected<Ret, Error>;
+#else
+template<typename Err>
+struct unexpected{
+    Err value;
+
+    explicit unexpected(Err e):value(e){}
+};
+
+/// This is a dumbed down version of C++23 std::expected, made better suited for
+/// embedded applications. It never throws, but uses NUNAVUT_ASSERT to signal
+/// exceptional cases.
+/// All versions of Ret are expected to be non-throwing.
+template<typename Ret>
+class expected{
+    // We can use a maximum of all types.
+    using storage_t = typename std::aligned_storage<
+        (std::max(sizeof(Ret), sizeof(Error))),
+        (std::max(alignof(Ret), alignof(Error)))>::type;
+    storage_t storage;
+    bool is_expected_;
+private:
+    Ret* ret_ptr() { return reinterpret_cast<Ret*>(&storage); }
+    const Ret* ret_ptr() const { return reinterpret_cast<const Ret*>(&storage); }
+    Error* error_ptr() { return reinterpret_cast<Error*>(&storage); }
+    const Error* error_ptr() const { return reinterpret_cast<const Error*>(&storage); }
+public:
+    expected():is_expected_(true){ new(ret_ptr()) Ret(); }
+    expected(Ret r):is_expected_(true){ new(ret_ptr()) Ret(std::move(r)); }
+    expected& operator=(Ret other){ this->~expected(); return *new(this) expected(std::move(other)); }
+    expected(unexpected<Error> err):is_expected_(false){ new(error_ptr()) Error(std::move(err.value)); }
+    expected(const expected& other): is_expected_(other.is_expected_){
+        if(is_expected_){ new(ret_ptr()) Ret(*other.ret_ptr()); }
+        else { new(error_ptr()) Error(*other.error_ptr()); }
+    }
+    expected& operator=(const expected& other){
+        this->~expected(); return *new(this) expected(other);
+    }
+    ~expected(){
+        if(is_expected_){ ret_ptr()->~Ret(); }
+        else{ error_ptr()->~Error(); }
+    }
+
+    Ret& value(){ {{ assert('is_expected_') }} return *ret_ptr(); }
+    const Ret& value() const { {{ assert('is_expected_') }} return *ret_ptr(); }
+    Ret& operator*(){ return value(); }
+    const Ret& operator*()const { return value(); }
+    Ret* operator->(){ {{ assert('is_expected_') }} return ret_ptr(); }
+    const Ret* operator->() const { {{ assert('is_expected_') }} return ret_ptr(); }
+    Error& error(){ {{ assert('not is_expected_') }} return *error_ptr(); }
+    const Error& error() const { {{ assert('not is_expected_') }} return *error_ptr(); }
+
+    bool has_value() const { return is_expected_; }
+    operator bool() const { return has_value(); }
+};
+
+template<>
+class expected<void>{
+    using underlying_type = typename std::underlying_type<Error>::type;
+    underlying_type e;
+public:
+    expected():e(0){}
+    expected(unexpected<Error> err):e(static_cast<underlying_type>(err.value)){ }
+    Error error() const { {{ assert('not has_value()') }} return static_cast<Error>(e); }
+
+    bool has_value() const { return e == 0; }
+    operator bool() const { return has_value(); }
+};
+
+template<typename Ret>
+using Result = expected<Ret>;
+#endif
+
+
 using VoidResult = Result<void>;
 using SerializeResult = Result<{{ typename_unsigned_length }}>;
+
+inline unexpected<Error> operator-(const Error& e){
+    return unexpected<Error>{e};
+}
 
 namespace options
 {

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -3,7 +3,7 @@
  # Copyright (C) 2021  UAVCAN Development Team  <uavcan.org>
  # This software is distributed under the terms of the MIT License.
  # Authors: David Lenfesty, Scott Dixon <dixonsco@amazon.com>, Pavel Kirienko <pavel@uavcan.org>,
- #          Peter van der Perk <peter.vanderperk@nxp.com>
+ #          Peter van der Perk <peter.vanderperk@nxp.com>, Pavel Pletenev <cpp.create@gmail.com>
 -#}
 
 {%- macro assert(expression) -%}
@@ -34,6 +34,8 @@ static_assert(__cplusplus >= 201100L,
 #include <cmath>  // For isfinite().
 {% endif -%}
 #include <cstdint>
+#include "span_lite.hpp"
+#include "tl_expected.hpp"
 
 static_assert(sizeof({{ typename_unsigned_bit_length }}) >= sizeof({{ typename_unsigned_length }}),
     "The bit-length type used by Nunavut, {{ typename_unsigned_bit_length }}, "
@@ -47,12 +49,436 @@ namespace nunavut
 namespace support
 {
 
+using nonstd::span;
+using bytespan = span<{{ typename_byte }}> ;
+using const_bytespan = span<const {{ typename_byte }}> ;
+#if span_FEATURE( MAKE_SPAN )
+using nonstd::make_span;
+#endif  // span_FEATURE( MAKE_SPAN )
+
+
+/// Nunavut serialization will never define more than 127 errors and the reserved error numbers are [1,127]
+/// (128 is not used). Error code 1 is currently also not used to avoid conflicts with 3rd-party software.
+enum class Error{
+    // API usage errors:
+    SERIALIZATION_INVALID_ARGUMENT = 2,
+    SERIALIZATION_BUFFER_TOO_SMALL = 3,
+    // Invalid representation (caused by bad input data, not API misuse):
+    REPRESENTATION_BAD_ARRAY_LENGTH=10,
+    REPRESENTATION_BAD_UNION_TAG=11,
+    REPRESENTATION_BAD_DELIMITER_HEADER=12
+};
+
+inline tl::unexpected<Error> operator-(const Error& e){
+    return tl::unexpected<Error>{e};
+}
+
+template<typename Ret>
+using Result = tl::expected<Ret, Error>;
+using VoidResult = Result<void>;
+using SerializeResult = Result<{{ typename_unsigned_length }}>;
+
 namespace options
 {
 {% for key, value in options.items() -%}
 constexpr std::uint32_t {{ key | id }} = {{ value | ln.c.to_static_assertion_value }};
 {% endfor %}
 } // end namespace options
+
+
+
+// ---------------------------------------------------- BIT ARRAY ----------------------------------------------------
+namespace detail{
+template<typename derived_bitspan>
+struct any_bitspan{
+protected:
+    const uint8_t* unchecked_aligned_ptr(std::size_t plus_offset_bits=0U) const noexcept {
+        auto& self  = *static_cast<const derived_bitspan*>(this);
+        const std::size_t offset_bytes = ((self.offset_bits_ + plus_offset_bits) / 8U);
+        return self.data_.data() + offset_bytes;
+    }
+public:
+    derived_bitspan at_offset({{ typename_unsigned_bit_length }} bits) const noexcept {
+        auto& self  = *static_cast<const derived_bitspan*>(this);
+        return derived_bitspan(self.data_, self.offset_bits_ + bits);
+    }
+
+    void add_offset({{ typename_unsigned_bit_length }} bits) noexcept{
+        auto& self  = *static_cast<derived_bitspan*>(this);
+        self.offset_bits_ += bits;
+    }
+
+    void set_offset({{ typename_unsigned_bit_length }} bits) noexcept{
+        auto& self  = *static_cast<derived_bitspan*>(this);
+        self.offset_bits_ = bits;
+    }
+
+    {{ typename_unsigned_bit_length }} size() const noexcept{
+        auto& self  = *static_cast<const derived_bitspan*>(this);
+        {{ typename_unsigned_bit_length }} bit_size = {# -#}
+            static_cast<{{ typename_unsigned_bit_length }}>(self.data_.size()) * 8U;
+        if(bit_size < self.offset_bits_){
+            return 0U;
+        }
+        return bit_size - self.offset_bits_;
+    }
+
+    {{ typename_byte }}& aligned_ref({{ typename_unsigned_length }} plus_offset_bits=0U) noexcept {
+        auto& self  = *static_cast<derived_bitspan*>(this);
+        const {{ typename_unsigned_length }} offset_bytes = ((self.offset_bits_ + plus_offset_bits) / 8U);
+        {{ assert('offset_bytes <= self.data_.size()') }}
+        return self.data_[offset_bytes];
+    }
+
+    const {{ typename_byte }}& aligned_ref({{ typename_unsigned_length }} plus_offset_bits=0U) const noexcept {
+        auto& self  = *static_cast<const derived_bitspan*>(this);
+        const {{ typename_unsigned_length }} offset_bytes = ((self.offset_bits_ + plus_offset_bits) / 8U);
+        {{ assert('offset_bytes <= self.data_.size()') }}
+        return self.data_[offset_bytes];
+    }
+
+    {{ typename_byte }}* aligned_ptr({{ typename_unsigned_length }} plus_offset_bits=0U) noexcept {
+        return &aligned_ref(plus_offset_bits);
+    }
+
+    const {{ typename_byte }}* aligned_ptr({{ typename_unsigned_length }} plus_offset_bits=0U) const noexcept {
+        return &aligned_ref(plus_offset_bits);
+    }
+};
+
+} // namespace detail
+
+struct bitspan: public detail::any_bitspan<bitspan>{
+    friend class detail::any_bitspan<bitspan>;
+    friend class const_bitspan;
+private:
+    bytespan data_;
+    {{ typename_unsigned_bit_length }} offset_bits_;
+public:
+    bitspan(bytespan data, {{ typename_unsigned_bit_length }} offset_bits=0)
+        :data_(std::move(data)), offset_bits_(offset_bits){
+    }
+    // ---------------------------------------------------- INTEGER ----------------------------------------------------
+    /// Serialize a DSDL field value at the specified bit offset from the beginning of the destination buffer.
+    /// The behavior is undefined if the input pointer is nullprt. The time complexity is linear of the bit length.
+    /// One-bit-wide signed integers are processed without raising an error but the result is unspecified.
+    ///
+    /// Arguments:
+    ///     value           The value itself (in case of integers it is promoted to 64-bit for unification).
+    ///     len_bits        Length of the serialized representation, in bits. Zero has no effect. Values >64 bit saturated.
+    VoidResult setBit(const bool value);
+
+    VoidResult setUxx(const uint64_t value, const uint8_t len_bits);
+
+    VoidResult setIxx(const int64_t value, const uint8_t len_bits);
+};
+
+struct const_bitspan: public detail::any_bitspan<const_bitspan>{
+    friend class detail::any_bitspan<const_bitspan>;
+private:
+    const_bytespan data_;
+    {{ typename_unsigned_bit_length }} offset_bits_;
+public:
+    const_bitspan(const_bytespan data, {{ typename_unsigned_bit_length }} offset_bits=0)
+        :data_(std::move(data)), offset_bits_(offset_bits){
+    }
+    /// Copy the specified number of bits from the source buffer into the destination buffer in accordance with the
+    /// DSDL bit-level serialization specification. The offsets may be arbitrary (may exceed 8 bits).
+    /// If both offsets are byte-aligned, the function invokes memmove() and possibly adjusts the last byte separately.
+    /// If the source and the destination overlap AND the offsets are not byte-aligned, the behavior is undefined.
+    /// If either source or destination pointers are NULL, the behavior is undefined.
+    /// Arguments:
+    ///     dst         Destination buffer. Shall be at least ceil(length_bits/8) bytes large.
+    ///     length_bits The number of bits to copy. Both source and destination shall be large enough.
+    void copyTo(bitspan dst){copyTo(dst, size());}
+    void copyTo({# -#}
+            bitspan dst,{# -#}
+            {{ typename_unsigned_bit_length }} length_bits) const noexcept {
+        {{ assert('data_.data() != nullptr') }}
+        {{ assert('dst.data_.data() != nullptr') }}
+        {{ assert('data_.data() != dst.data_.data()') }}
+        if(length_bits > size()){
+            length_bits = size();
+        }
+        if(length_bits == 0){
+            return;
+        }
+        {{ assert('length_bits <= dst.size()') }}
+        if ((0U == (offset_bits_ % 8U)) && (0U == (dst.offset_bits_ % 8U)))  // Aligned copy, optimized, most common case.
+        {
+            const {{ typename_unsigned_length }} length_bytes = static_cast<{{ typename_unsigned_length }}>(length_bits / 8U);
+
+            (void) memmove(dst.aligned_ptr(), aligned_ptr(), length_bytes);
+            const uint8_t length_mod = static_cast<uint8_t>(length_bits % 8U);
+            if (0U != length_mod)  // If the length is unaligned, the last byte requires special treatment.
+            {
+                {{ assert('length_mod < 8U') }}
+                const uint8_t mask = static_cast<uint8_t>((1U << length_mod) - 1U);
+                dst.data_[length_bytes] = (dst.data_[length_bytes] & static_cast<{{ typename_byte }}>(~mask)) | (data_[length_bytes] & mask);
+            }
+        }
+        else
+        {
+            // The algorithm was originally designed by Ben Dyer for Libuavcan v0:
+            // https://github.com/UAVCAN/libuavcan/blob/legacy-v0/libuavcan/src/marshal/uc_bit_array_copy.cpp
+            // This version is modified for v1 where the bit order is the opposite.
+            {{ typename_unsigned_bit_length }}       src_off  = offset_bits_;
+            {{ typename_unsigned_bit_length }}       dst_off  = dst.offset_bits_;
+            const {{ typename_unsigned_bit_length }} last_bit = src_off + length_bits;
+            {{ assert(
+                '((aligned_ptr() < dst.aligned_ptr()) ? (unchecked_aligned_ptr(length_bits) <= dst.aligned_ptr()) : true)'
+            ) }}
+            {{ assert(
+                '((aligned_ptr() > dst.aligned_ptr()) ? (dst.unchecked_aligned_ptr(length_bits) <= aligned_ptr()) : true)'
+            ) }}
+            while (last_bit > src_off)
+            {
+                const uint8_t src_mod = (src_off % 8U);
+                const uint8_t dst_mod = (dst_off % 8U);
+                const uint8_t max_mod = (src_mod > dst_mod) ? src_mod : dst_mod;
+                const {{ typename_unsigned_bit_length }} max_mod_inv = 8U - max_mod;
+                const {{ typename_unsigned_bit_length }} last_off = last_bit - src_off;
+                const uint8_t size = static_cast<uint8_t>(std::min(max_mod_inv, last_off));
+                {{ assert('size > 0U') }}
+                {{ assert('size <= 8U') }}
+                // Suppress a false warning from Clang-Tidy & Sonar that size is being over-shifted. It's not.
+                const uint8_t mask = ((((1U << size) - 1U) << dst_mod) & 0xFFU);  // NOLINT NOSONAR
+                {{ assert('mask > 0U') }}
+                // Intentional violation of MISRA: indexing on a pointer.
+                // This simplifies the implementation greatly and avoids pointer arithmetics.
+                const uint8_t in = static_cast<uint8_t>(static_cast<uint8_t>(data_[src_off / 8U] >> src_mod) << dst_mod) & 0xFFU;  // NOSONAR
+                // Intentional violation of MISRA: indexing on a pointer.
+                // This simplifies the implementation greatly and avoids pointer arithmetics.
+                const uint8_t a = dst.data_[dst_off / 8U] & (static_cast<uint8_t>(~mask));  // NOSONAR
+                const uint8_t b = in & mask;
+                // Intentional violation of MISRA: indexing on a pointer.
+                // This simplifies the implementation greatly and avoids pointer arithmetics.
+                dst.data_[dst_off / 8U] = a | b;  // NOSONAR
+                src_off += size;
+                dst_off += size;
+            }
+            {{ assert('last_bit == src_off') }}
+        }
+    }
+
+    /// Calculate the number of bits to safely copy from/to a serialized buffer.
+    /// Mind the units! By convention, buffer size is specified in bytes, but fragment length and offset are in bits.
+    ///
+    ///      buffer                                                                buffer
+    ///      origin                                                                 end
+    ///         [------------------------------ data_.size() ------------------------]
+    ///         [-------------------- offset_bits_ ------------------][--- fragment_length_bits ---]
+    ///                                                               [-- out bits --]
+    ///                                                                              ^
+    ///                                       this position is returned -------------/
+    ///
+    {{ typename_unsigned_bit_length }} saturateBufferFragmentBitLength({# -#}
+        const {{ typename_unsigned_bit_length }} fragment_length_bits) const noexcept
+    {
+        const {{ typename_unsigned_bit_length }} size_bits = static_cast<{{ typename_unsigned_bit_length }}>(data_.size()) * 8U;
+        const {{ typename_unsigned_bit_length }} tail_bits = size_bits - std::min(size_bits, offset_bits_);
+        return std::min(fragment_length_bits, tail_bits);
+    }
+
+    /// This function is intended for deserialization of contiguous sequences of zero-cost primitives.
+    /// It extracts (len_bits) bits that are offset by (offset_bits_) from the origin of (data_) whose size is (data_.size()).
+    /// If the requested (len_bits+offset_bits_) overruns the buffer, the missing bits are implicitly zero-extended.
+    /// If (len_bits % 8 != 0), the output buffer is right-zero-padded up to the next byte boundary.
+    /// If (off_bits % 8 == 0), the operation is delegated to memmove(); otherwise, a much slower unaligned bit copy
+    /// algorithm is employed. See @ref nunavutCopyBits() for further details.
+    void getBits(bytespan output, const {{ typename_unsigned_bit_length }} len_bits)
+    {
+        {{ assert('output.data() != nullptr') }}
+        {{ assert('data_.data() != nullptr') }}
+        const {{ typename_unsigned_length }} len_bytes = (len_bits + 7U) / 8U;
+        {{ assert('output.size() >= len_bytes') }}
+        const {{ typename_unsigned_bit_length }} sat_bits = saturateBufferFragmentBitLength(len_bits);
+        // Apply implicit zero extension. Normally, this is a no-op unless (len_bits > sat_bits) or (len_bits % 8 != 0).
+        // The former case ensures that if we're copying <8 bits, the MSB in the destination will be zeroed out.
+        std::memset(output.data() + (sat_bits / 8U), 0, len_bytes - (sat_bits / 8U));
+        copyTo(bitspan{output, 0U}, sat_bits);
+    }
+
+
+
+    /// Deserialize a DSDL field value located at the specified bit offset from the beginning of the source buffer.
+    /// If the deserialized value extends beyond the end of the buffer, the missing bits are taken as zero, as required
+    /// by the DSDL specification (see Implicit Zero Extension Rule, IZER).
+    ///
+    /// If len_bits is greater than the return type, extra bits will be truncated per standard narrowing conversion rules.
+    /// If len_bits is shorter than the return type, missing bits will be zero per standard integer promotion rules.
+    /// Essentially, for integers, it would be enough to have 64-bit versions only; narrower variants exist only to avoid
+    /// narrowing type conversions of the result and for some performance gains.
+    ///
+    /// The behavior is undefined if the input pointer is NULL. The time complexity is linear of the bit length.
+    /// One-bit-wide signed integers are processed without raising an error but the result is unspecified.
+    ///
+    /// Arguments:
+    ///     len_bits        Length of the serialized representation, in bits. Zero returns 0. Out-of-range values saturated.
+
+    bool getBit() const noexcept
+    {
+        return 1U == getU8(1U);
+    }
+
+    uint8_t getU8(const uint8_t len_bits) const noexcept
+    {
+        {{ assert('data_.data() != nullptr') }}
+        const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 8U));
+        {{ assert('bits <= (sizeof(uint8_t) * 8U)') }}
+        uint8_t val = 0;
+        copyTo(bitspan{ { &val, 1U } }, bits);
+        return val;
+    }
+
+    uint16_t getU16(const uint8_t len_bits) const noexcept
+    {
+        {{ assert('data_.data() != nullptr') }}
+        const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 16U));
+        {{ assert('bits <= (sizeof(uint16_t) * 8U)') }}
+    {%- if options.target_endianness == 'little' %}
+        uint16_t val = 0U;
+        copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
+        return val;
+    {%- elif options.target_endianness in ('any', 'big') %}
+        uint8_t tmp[sizeof(uint16_t)] = {0};
+        copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
+        return static_cast<uint16_t>(static_cast<uint16_t>(tmp[0]) | ((static_cast<uint16_t>(tmp[1])) << 8U));
+    {%- else %}{%- assert False %}
+    {%- endif %}
+    }
+
+    uint32_t getU32(const uint8_t len_bits) const noexcept
+    {
+        {{ assert('data_.data() != nullptr') }}
+        const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 32U));
+        {{ assert('bits <= (sizeof(uint32_t) * 8U)') }}
+    {%- if options.target_endianness == 'little' %}
+        uint32_t val = 0U;
+        copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
+        return val;
+    {%- elif options.target_endianness in ('any', 'big') %}
+        uint8_t tmp[sizeof(uint32_t)] = {0};
+        copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
+        return static_cast<uint32_t>(static_cast<uint32_t>(tmp[0]) |
+                        (static_cast<uint32_t>(tmp[1]) << 8U) |
+                        (static_cast<uint32_t>(tmp[2]) << 16U) |
+                        (static_cast<uint32_t>(tmp[3]) << 24U));
+    {%- else %}{%- assert False %}
+    {%- endif %}
+    }
+
+    uint64_t getU64(const uint8_t len_bits) const noexcept
+    {
+        {{ assert('data_.data() != nullptr') }}
+        const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 64U));
+        {{ assert('bits <= (sizeof(uint64_t) * 8U)') }}
+    {%- if options.target_endianness == 'little' %}
+        uint64_t val = 0U;
+        copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
+        return val;
+    {%- elif options.target_endianness in ('any', 'big') %}
+        uint8_t tmp[sizeof(uint64_t)] = {0};
+        copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
+        return static_cast<uint64_t>(static_cast<uint64_t>(tmp[0]) |
+                        (static_cast<uint64_t>(tmp[1]) << 8U) |
+                        (static_cast<uint64_t>(tmp[2]) << 16U) |
+                        (static_cast<uint64_t>(tmp[3]) << 24U) |
+                        (static_cast<uint64_t>(tmp[4]) << 32U) |
+                        (static_cast<uint64_t>(tmp[5]) << 40U) |
+                        (static_cast<uint64_t>(tmp[6]) << 48U) |
+                        (static_cast<uint64_t>(tmp[7]) << 56U));
+    {%- else %}{%- assert False %}
+    {%- endif %}
+    }
+
+    int8_t getI8(const uint8_t len_bits) const noexcept
+    {
+        const uint8_t sat = std::min<uint8_t>(len_bits, 8U);
+        uint8_t       val = getU8(sat);
+        const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
+        val = ((sat < 8U) && neg) ? static_cast<uint8_t>(val | ~((1U << sat) - 1U)) : val;  // Sign extension
+        return neg ? static_cast<int8_t>(-static_cast<int8_t>(static_cast<uint8_t>(~val)) - 1) : static_cast<int8_t>(val);
+    }
+
+    int16_t getI16(const uint8_t len_bits) const noexcept
+    {
+        const uint8_t sat = std::min<uint8_t>(len_bits, 16U);
+        uint16_t      val = getU16(sat);
+        const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
+        val = ((sat < 16U) && neg) ? static_cast<uint16_t>(val | ~((1U << sat) - 1U)) : val;  // Sign extension
+        return neg ? static_cast<int16_t>(-static_cast<int16_t>(static_cast<uint16_t>(~val)) - 1) : static_cast<int16_t>(val);
+    }
+
+    int32_t getI32(const uint8_t len_bits) const noexcept
+    {
+        const uint8_t sat = std::min<uint8_t>(len_bits, 32U);
+        uint32_t      val = getU32(sat);
+        const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
+        val = ((sat < 32U) && neg) ? static_cast<uint32_t>(val | ~((1UL << sat) - 1U)) : val;  // Sign extension
+        return neg ? static_cast<int32_t>((-static_cast<int32_t>(~val)) - 1) : static_cast<int32_t>(val);
+    }
+
+    int64_t getI64(const uint8_t len_bits) const noexcept
+    {
+        const uint8_t sat = std::min<uint8_t>(len_bits, 64U);
+        uint64_t      val = getU64(sat);
+        const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
+        val = ((sat < 64U) && neg) ? static_cast<uint64_t>(val | ~((1ULL << sat) - 1U)) : val;  // Sign extension
+        return neg ? static_cast<int64_t>((-static_cast<int64_t>(~val)) - 1) : static_cast<int64_t>(val);
+    }
+};
+
+VoidResult bitspan::setBit(const bool value)
+{
+    if ((data_.size() * 8U) <= offset_bits_)
+    {
+        return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
+    }
+    const uint8_t val = value ? 1U : 0U;
+    const_bitspan{ { &val, 1U } }.copyTo(*this, 1U);
+    return {};
+}
+
+VoidResult bitspan::setUxx(const uint64_t value, const uint8_t len_bits)
+{
+    static_assert(64U == (sizeof(uint64_t) * 8U), "Unexpected size of uint64_t");
+    if ((data_.size() * 8) < (offset_bits_ + len_bits))
+    {
+        return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
+    }
+    const {{ typename_unsigned_bit_length }} saturated_len_bits = std::min<{{ typename_unsigned_bit_length }}>({# -#}
+        len_bits, 64U);
+{%- if options.target_endianness == 'little' %}
+        bitspan{ { reinterpret_cast<const uint8_t*>(&value), sizeof(uint64_t) } }.copyTo(*this, saturated_len_bits);
+{%- elif options.target_endianness in ('any', 'big') %}
+    std::array<uint8_t, 8> tmp{
+        static_cast<uint8_t>((value >> 0U) & 0xFFU),
+        static_cast<uint8_t>((value >> 8U) & 0xFFU),
+        static_cast<uint8_t>((value >> 16U) & 0xFFU),
+        static_cast<uint8_t>((value >> 24U) & 0xFFU),
+        static_cast<uint8_t>((value >> 32U) & 0xFFU),
+        static_cast<uint8_t>((value >> 40U) & 0xFFU),
+        static_cast<uint8_t>((value >> 48U) & 0xFFU),
+        static_cast<uint8_t>((value >> 56U) & 0xFFU),
+    };
+    const_bitspan{ { &tmp[0], sizeof(uint64_t) } }.copyTo(*this, saturated_len_bits);
+{%- else %}{%- assert False %}
+{%- endif %}
+    return {};
+}
+
+VoidResult bitspan::setIxx(const int64_t value, const uint8_t len_bits)
+{
+    // The naive sign conversion is safe and portable according to the C++ Standard 4.7/2 :
+    // If the destination type is unsigned, the resulting value is the least unsigned integer
+    // congruent to the source integer (modulo 2^n where n is the number of bits used to represent
+    // the unsigned type). [Note: In a two's complement representation, this conversion is conceptual and there
+    // is no change in the bit pattern (if there is no truncation). ]
+    return setUxx(static_cast<uint64_t>(value), len_bits);
+}
+
+
 } // end namespace support
 } // end namespace nunavut
 

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -140,6 +140,16 @@ public:
         return derived_bitspan(self.data_, self.offset_bits_ + bits);
     }
 
+    derived_bitspan subspan({{ typename_unsigned_bit_length }} bits_at=0) const noexcept {
+        auto& self  = *static_cast<const derived_bitspan*>(this);
+        const {{ typename_unsigned_bit_length }} offset_bits = self.offset_bits_ + bits_at;
+        const {{ typename_unsigned_length }} offset_bytes = offset_bits / 8U;
+        {{ assert('offset_bytes * 8U <= offset_bits') }}
+        const {{ typename_unsigned_length }} new_offset_bits = offset_bits - offset_bytes * 8U;
+        {{ assert('offset_bytes <= self.data_.size()') }}
+        return derived_bitspan({ self.data_.data() + offset_bytes, self.data_.size() - offset_bytes}, new_offset_bits);
+    }
+
     void add_offset({{ typename_unsigned_bit_length }} bits) noexcept{
         auto& self  = *static_cast<derived_bitspan*>(this);
         self.offset_bits_ += bits;
@@ -148,6 +158,19 @@ public:
     void set_offset({{ typename_unsigned_bit_length }} bits) noexcept{
         auto& self  = *static_cast<derived_bitspan*>(this);
         self.offset_bits_ = bits;
+    }
+
+    {{ typename_unsigned_bit_length }} offset_misalignment({{ typename_unsigned_bit_length }} alignment_bits) const noexcept{
+        auto& self  = *static_cast<const derived_bitspan*>(this);
+        return self.offset_bits_ % alignment_bits;
+    }
+
+    bool offset_alings_to({{ typename_unsigned_bit_length }} alignment_bits) const noexcept{
+        return offset_misalignment(alignment_bits) == 0U;
+    }
+
+    bool offset_alings_to_byte() const noexcept{
+        return offset_alings_to(8U);
     }
 
     {{ typename_unsigned_bit_length }} size() const noexcept{
@@ -160,27 +183,45 @@ public:
         return bit_size - self.offset_bits_;
     }
 
-    {{ typename_byte }}& aligned_ref({{ typename_unsigned_length }} plus_offset_bits=0U) noexcept {
+    {{ typename_unsigned_bit_length }} offset() const noexcept {
+        auto& self  = *static_cast<const derived_bitspan*>(this);
+        return self.offset_bits_;
+    }
+
+    {{ typename_unsigned_bit_length }} offset_bytes() const noexcept {
+        auto& self  = *static_cast<const derived_bitspan*>(this);
+        const {{ typename_unsigned_length }} offset_bytes = (self.offset_bits_) / 8U;
+        return offset_bytes ;
+    }
+
+    {{ typename_unsigned_bit_length }} offset_bytes_ceil() const noexcept {
+        auto& self  = *static_cast<const derived_bitspan*>(this);
+        const {{ typename_unsigned_length }} offset_bytes = ((self.offset_bits_ + 7U) / 8U);
+        return offset_bytes ;
+    }
+
+    {{ typename_byte }}& aligned_ref({{ typename_unsigned_bit_length }} plus_offset_bits=0U) noexcept {
         auto& self  = *static_cast<derived_bitspan*>(this);
         const {{ typename_unsigned_length }} offset_bytes = ((self.offset_bits_ + plus_offset_bits) / 8U);
         {{ assert('offset_bytes <= self.data_.size()') }}
         return self.data_[offset_bytes];
     }
 
-    const {{ typename_byte }}& aligned_ref({{ typename_unsigned_length }} plus_offset_bits=0U) const noexcept {
+    const {{ typename_byte }}& aligned_ref({{ typename_unsigned_bit_length }} plus_offset_bits=0U) const noexcept {
         auto& self  = *static_cast<const derived_bitspan*>(this);
         const {{ typename_unsigned_length }} offset_bytes = ((self.offset_bits_ + plus_offset_bits) / 8U);
         {{ assert('offset_bytes <= self.data_.size()') }}
         return self.data_[offset_bytes];
     }
 
-    {{ typename_byte }}* aligned_ptr({{ typename_unsigned_length }} plus_offset_bits=0U) noexcept {
+    {{ typename_byte }}* aligned_ptr({{ typename_unsigned_bit_length }} plus_offset_bits=0U) noexcept {
         return &aligned_ref(plus_offset_bits);
     }
 
-    const {{ typename_byte }}* aligned_ptr({{ typename_unsigned_length }} plus_offset_bits=0U) const noexcept {
+    const {{ typename_byte }}* aligned_ptr({{ typename_unsigned_bit_length }} plus_offset_bits=0U) const noexcept {
         return &aligned_ref(plus_offset_bits);
     }
+
 };
 
 } // namespace detail
@@ -214,6 +255,11 @@ public:
     VoidResult setF32(const {{ typename_float_32 }} value);
 
     VoidResult setF64(const {{ typename_float_64 }} value);
+
+    VoidResult setZeros() { return setZeros(size()); }
+    VoidResult setZeros({{ typename_unsigned_bit_length }} length);
+
+    VoidResult padAndMoveToAlignment({{ typename_unsigned_bit_length }} length);
 };
 
 struct const_bitspan: public detail::any_bitspan<const_bitspan>{
@@ -257,7 +303,10 @@ public:
             {
                 {{ assert('length_mod < 8U') }}
                 const uint8_t mask = static_cast<uint8_t>((1U << length_mod) - 1U);
-                dst.data_[length_bytes] = (dst.data_[length_bytes] & static_cast<{{ typename_byte }}>(~mask)) | (data_[length_bytes] & mask);
+                //dst.data_[length_bytes] = (dst.data_[length_bytes] & static_cast<{{ typename_byte }}>(~mask)) | (data_[length_bytes] & mask);
+                dst.aligned_ref(length_bits) = {# -#}
+                    (dst.aligned_ref(length_bits) & static_cast<{{ typename_byte }}>(~mask)) {# -#}
+                    | (aligned_ref(length_bits) & mask);
             }
         }
         else
@@ -292,7 +341,7 @@ public:
                 const uint8_t in = static_cast<uint8_t>(static_cast<uint8_t>(data_[src_off / 8U] >> src_mod) << dst_mod) & 0xFFU;  // NOSONAR
                 // Intentional violation of MISRA: indexing on a pointer.
                 // This simplifies the implementation greatly and avoids pointer arithmetics.
-                const uint8_t a = dst.data_[dst_off / 8U] & (static_cast<uint8_t>(~mask));  // NOSONAR
+                const uint8_t a = dst.data_[dst_off / 8U] & (static_cast<uint8_t>((~mask) & 0xFFU));  // NOSONAR
                 const uint8_t b = in & mask;
                 // Intentional violation of MISRA: indexing on a pointer.
                 // This simplifies the implementation greatly and avoids pointer arithmetics.
@@ -302,6 +351,12 @@ public:
             }
             {{ assert('last_bit == src_off') }}
         }
+    }
+
+    template<{{ typename_unsigned_bit_length }} n_bits>
+    void align_offset_to(){
+        static_assert((n_bits == 8) or (n_bits == 16) or (n_bits == 32) or (n_bits == 64), "Non-standard alignment!");
+        offset_bits_ = (offset_bits_ + (n_bits - 1)) & ~(static_cast<{{ typename_unsigned_bit_length }}>(n_bits - 1));
     }
 
     /// Calculate the number of bits to safely copy from/to a serialized buffer.
@@ -387,6 +442,39 @@ public:
     {{ typename_float_64 }} getF64();
 };
 
+VoidResult bitspan::setZeros({{ typename_unsigned_bit_length }} length){
+    if(length > size()){
+        return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
+    }
+    if(length == 0){
+        return {};
+    }
+    const {{ typename_unsigned_length }} offset_bytes = offset_bits_ / 8U;
+    const {{ typename_unsigned_bit_length }} offset_bits_mod = offset_bits_ % 8U;
+    const {{ typename_unsigned_bit_length }} length_bytes_ceil = (length + 7U) / 8U;
+    {{ assert('offset_bits_mod < 8U') }}
+    const auto first_byte_temp = data_[offset_bytes] & static_cast<{{ typename_byte }}>(0xFF >> (8U - offset_bits_mod));
+    memset(&data_[offset_bytes], 0, length_bytes_ceil);
+    data_[offset_bytes] =  static_cast<{{ typename_byte }}>(data_[offset_bytes] | first_byte_temp);
+    return {};
+}
+
+VoidResult bitspan::padAndMoveToAlignment({{ typename_unsigned_bit_length }} n_bits){
+    const auto padding = static_cast<uint8_t>(n_bits - offset_misalignment(n_bits));
+    if (padding != n_bits)  // Pad to n_bits bits. TODO: Eliminate redundant padding checks.
+    {
+        {{ assert('padding > 0') }}
+        auto ref_result = setZeros(padding);
+        if(not ref_result){
+            return ref_result;
+        }
+        add_offset( padding);
+        {{ assert('offset_alings_to(n_bits)') }}
+    }
+    return {};
+}
+
+
 uint8_t const_bitspan::getU8(const uint8_t len_bits) const noexcept
 {
     {{ assert('data_.data() != nullptr') }}
@@ -425,11 +513,12 @@ uint32_t const_bitspan::getU32(const uint8_t len_bits) const noexcept
     return val;
 {%- elif options.target_endianness in ('any', 'big') %}
     uint8_t tmp[sizeof(uint32_t)] = {0};
-    copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
-    return static_cast<uint32_t>(static_cast<uint32_t>(tmp[0]) |
-                    (static_cast<uint32_t>(tmp[1]) << 8U) |
-                    (static_cast<uint32_t>(tmp[2]) << 16U) |
-                    (static_cast<uint32_t>(tmp[3]) << 24U));
+    copyTo(bitspan{ { tmp, sizeof(tmp) } }, bits);
+    return static_cast<uint32_t>(
+        (static_cast<uint32_t>(tmp[0])) |
+        (static_cast<uint32_t>(tmp[1]) << 8U) |
+        (static_cast<uint32_t>(tmp[2]) << 16U) |
+        (static_cast<uint32_t>(tmp[3]) << 24U));
 {%- else %}{%- assert False %}
 {%- endif %}
 }
@@ -445,7 +534,7 @@ uint64_t const_bitspan::getU64(const uint8_t len_bits) const noexcept
     return val;
 {%- elif options.target_endianness in ('any', 'big') %}
     uint8_t tmp[sizeof(uint64_t)] = {0};
-    copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
+    copyTo(bitspan{ { tmp, sizeof(tmp) } }, bits);
     return static_cast<uint64_t>(static_cast<uint64_t>(tmp[0]) |
                     (static_cast<uint64_t>(tmp[1]) << 8U) |
                     (static_cast<uint64_t>(tmp[2]) << 16U) |

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -54,6 +54,9 @@
     static constexpr {{ typename_unsigned_length }} SERIALIZATION_BUFFER_SIZE_BYTES = {#- -#}
         {{ composite_type.inner_type.extent // 8 }}UL;
     static_assert(EXTENT_BYTES >= SERIALIZATION_BUFFER_SIZE_BYTES, "Internal constraint violation");
+    static_assert({# -#}
+        EXTENT_BYTES < (std::numeric_limits<{{ typename_unsigned_bit_length }}>::max() /8U), {# -#}
+        "This message is too large to be handled by current types!");
 
 {%- for constant in composite_type.constants %}
     {% if loop.first %}
@@ -64,12 +67,26 @@
     {{ constant.doc | block_comment('cpp-doxygen', 4, 120) }}
     static constexpr {{ constant.data_type | declaration }} {{ constant.name | id }} = {{ constant | constant_value }};
 {%- endfor -%}
-{%- if composite_type is UnionType -%}
+{%- if composite_type.inner_type is UnionType -%}
 {%- ifuses "std_variant" -%}
 {% include '_fields_as_variant.j2' %}
 {%- else -%}
 {% include '_fields_as_union.j2' %}
 {%- endifuses -%}
+{%- for field in composite_type.fields_except_padding %}
+    typename std::add_pointer<{{ field.data_type | declaration }}>::type get_{{ field.name | id }}_if(){
+        return VariantType::get_if<VariantType::IndexOf::{{ field.name | id }}>(&union_value);
+    }
+
+    typename std::add_pointer<const {{ field.data_type | declaration }}>::type get_{{ field.name | id }}_if() const{
+        return VariantType::get_if<VariantType::IndexOf::{{ field.name | id }}>(&union_value);
+    }
+
+    template<class... Args> typename std::add_lvalue_reference<{{ field.data_type | declaration }}>::type
+    set_{{ field.name | id }}(Args&&...v){
+        return union_value.emplace<VariantType::IndexOf::{{ field.name | id }}>(v...);
+    }
+{%- endfor %}
 {%- else -%}
 {% include '_fields.j2' %}
 {%- endif -%}

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -39,6 +39,22 @@
     /// This type does not have a fixed port-ID. See https://forum.uavcan.org/t/choosing-message-and-service-ids/889
     static constexpr bool HasFixedPortID = false;
 {% endif -%}
+    {%- assert composite_type.extent % 8 == 0 %}
+    {%- assert composite_type.inner_type.extent % 8 == 0 %}
+    /// Extent is the minimum amount of memory required to hold any serialized representation of any compatible
+    /// version of the data type; or, on other words, it is the the maximum possible size of received objects of this type.
+    /// The size is specified in bytes (rather than bits) because by definition, extent is an integer number of bytes long.
+    /// When allocating a deserialization (RX) buffer for this data type, it should be at least extent bytes large.
+    /// When allocating a serialization (TX) buffer, it is safe to use the size of the largest serialized representation
+    /// instead of the extent because it provides a tighter bound of the object size; it is safe because the concrete type
+    /// is always known during serialization (unlike deserialization). If not sure, use extent everywhere.
+
+    static constexpr {{ typename_unsigned_length }} EXTENT_BYTES                    = {#- -#}
+        {{ composite_type.extent // 8 }}UL;
+    static constexpr {{ typename_unsigned_length }} SERIALIZATION_BUFFER_SIZE_BYTES = {#- -#}
+        {{ composite_type.inner_type.extent // 8 }}UL;
+    static_assert(EXTENT_BYTES >= SERIALIZATION_BUFFER_SIZE_BYTES, "Internal constraint violation");
+
 {%- for constant in composite_type.constants %}
     {% if loop.first %}
     // +---------------------------------------------------------------------------------------------------------------+
@@ -60,11 +76,17 @@
 {%- if not nunavut.support.omit %}
 
     nunavut::support::SerializeResult
-    serialize(nunavut::support::span<{{ typename_byte }}> out_buffer) const
+    serialize(nunavut::support::bitspan out_buffer) const
     {
-        (void)out_buffer;
         {% from 'serialization.j2' import serialize -%}
-        {{ serialize(composite_type) | trim }}
+        {{ serialize(composite_type) | trim | remove_blank_lines | indent }}
+    }
+
+    nunavut::support::SerializeResult
+    deserialize(nunavut::support::const_bitspan in_buffer)
+    {
+        {% from 'deserialization.j2' import deserialize -%}
+        {{ deserialize(composite_type) | trim | remove_blank_lines | indent }}
     }
 {%- endif %}
 }{{ composite_type | definition_end }}

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -74,6 +74,10 @@
 {% include '_fields_as_union.j2' %}
 {%- endifuses -%}
 {%- for field in composite_type.fields_except_padding %}
+    bool is_{{ field.name | id }}() const {
+        return VariantType::IndexOf::{{ field.name | id }} == union_value.index();
+    }
+
     typename std::add_pointer<{{ field.data_type | declaration }}>::type get_{{ field.name | id }}_if(){
         return VariantType::get_if<VariantType::IndexOf::{{ field.name | id }}>(&union_value);
     }

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -58,11 +58,13 @@
 {% include '_fields.j2' %}
 {%- endif -%}
 {%- if not nunavut.support.omit %}
-    {{ typename_unsigned_length }} serialize(std::size_t todo_ser = 0)
+
+    nunavut::support::SerializeResult
+    serialize(nunavut::support::span<{{ typename_byte }}> out_buffer) const
     {
-        // TODO: implement this routine
-        (void)todo_ser;
-        return 0;
+        (void)out_buffer;
+        {% from 'serialization.j2' import serialize -%}
+        {{ serialize(composite_type) | trim }}
     }
 {%- endif %}
 }{{ composite_type | definition_end }}

--- a/src/nunavut/lang/cpp/templates/_definitions.j2
+++ b/src/nunavut/lang/cpp/templates/_definitions.j2
@@ -1,0 +1,12 @@
+{%- macro assert(expression) -%}
+    {%- if options.enable_serialization_asserts -%}
+    NUNAVUT_ASSERT({{ expression }});
+    {%- endif -%}
+{%- endmacro -%}
+
+{% if options.target_endianness == 'little' %}
+    {% set LITTLE_ENDIAN = True %}
+{% elif options.target_endianness in ('any', 'big') %}
+    {% set LITTLE_ENDIAN = False %}
+{% else %}{% assert False %}
+{% endif %}

--- a/src/nunavut/lang/cpp/templates/_fields_as_union.j2
+++ b/src/nunavut/lang/cpp/templates/_fields_as_union.j2
@@ -5,30 +5,30 @@
 #}
     class VariantType final
     {
+        std::size_t tag_;
+
+        union internal_union_t
+        {
+{%- for field in composite_type.fields_except_padding %}
+            {{ field.doc | block_comment('cpp-doxygen', 12, 120) }}
+            std::aligned_storage<sizeof({{ field.data_type | declaration }}), alignof({{ field.data_type | declaration }})>::type {{ field.name | id }};
+{%- endfor %}
+        } internal_union_value_;
+
     public:
         static const constexpr std::size_t variant_npos = -1;
 
         VariantType()
             : tag_(0)
             , internal_union_value_()
-            , storage_index_{
-{%- for field in composite_type.fields_except_padding %}
-                {% if not loop.first %}, {% else %}  {% endif %}&internal_union_value_.{{ field.name | id }}
-{%- endfor %}
-            }
         {
             // This is how the C++17 standard library does it; default initialization as the 0th index.
-            new (storage_index_[0]) typename alternative<0>::type();
+            emplace<0>();
         }
 
         VariantType(const VariantType& rhs)
             : tag_(variant_npos)
             , internal_union_value_()
-            , storage_index_{
-{%- for field in composite_type.fields_except_padding %}
-                {% if not loop.first %}, {% else %}  {% endif %}&internal_union_value_.{{ field.name | id }}
-{%- endfor %}
-            }
         {
 {%- for field in composite_type.fields_except_padding %}
             {% if not loop.first %}else {% endif %}if(rhs.tag_ == {{ loop.index0 }})
@@ -44,11 +44,6 @@
         VariantType(VariantType&& rhs)
             : tag_(variant_npos)
             , internal_union_value_()
-            , storage_index_{
-{%- for field in composite_type.fields_except_padding %}
-                {% if not loop.first %}, {% else %}  {% endif %}&internal_union_value_.{{ field.name | id }}
-{%- endfor %}
-            }
         {
 {%- for field in composite_type.fields_except_padding %}
             {% if not loop.first %}else {% endif %}if(rhs.tag_ == {{ loop.index0 }})
@@ -99,6 +94,10 @@
             destroy_current();
         }
 
+        size_t index() const{
+            return tag_;
+        }
+
         struct IndexOf final
         {
             IndexOf() = delete;
@@ -108,16 +107,13 @@
         };
         static constexpr const std::size_t MAX_INDEX = {{ composite_type.fields_except_padding  | length }}U;
 
-        size_t index() const{
-            return tag_;
-        }
-
         template<std::size_t I, class...Types> struct alternative;
 
 {% for field in composite_type.fields_except_padding %}
         template<class...Types> struct alternative<{{ loop.index0 }}U, Types...>
         {
             using type = {{ field.data_type | declaration }};
+            static constexpr auto pointer = &VariantType::internal_union_t::{{ field.name | id }};
         };
 {%- endfor %}
 
@@ -144,24 +140,32 @@
     private:
         template<std::size_t I, class... Args> typename VariantType::alternative<I, VariantType>::type& do_emplace(Args&&... v)
         {
-            return *(new (storage_index_[I]) typename alternative<I>::type(std::forward<typename alternative<I>::type>(v...)));
+            return *(new (&(internal_union_value_.*(alternative<I>::pointer)) ) {# -#}
+                typename alternative<I>::type(std::forward<Args>(v)...));
         }
 
         template<std::size_t I, class... Args> typename VariantType::alternative<I, VariantType>::type& do_copy(const Args&... v)
         {
-            return *(new (storage_index_[I]) typename alternative<I>::type(typename alternative<I>::type(v...)));
+            return *(new (&(internal_union_value_.*(alternative<I>::pointer)) ) {# -#}
+                typename alternative<I>::type(typename alternative<I>::type(v...)));
         }
 
         template<std::size_t I, class... Types>
         constexpr typename VariantType::alternative<I, VariantType>::type* do_get_if() noexcept
         {
-            return (tag_ == I) ? reinterpret_cast<typename std::add_pointer<typename VariantType::alternative<I>::type>::type>(storage_index_[I]) : nullptr;
+            return (tag_ == I) ? {# -#}
+                reinterpret_cast<typename std::add_pointer<typename VariantType::alternative<I>::type>::type>({# -#}
+                    &(internal_union_value_.*(alternative<I>::pointer)){# -#}
+                ) : nullptr;
         }
 
         template<std::size_t I, class... Types>
         constexpr const typename VariantType::alternative<I, VariantType>::type* do_get_if_const() const noexcept
         {
-            return (tag_ == I) ? reinterpret_cast<typename std::add_pointer<const typename VariantType::alternative<I>::type>::type>(storage_index_[I]) : nullptr;
+            return (tag_ == I) ? {# -#}
+                reinterpret_cast<typename std::add_pointer<const typename VariantType::alternative<I>::type>::type>({# -#}
+                    &(internal_union_value_.*(alternative<I>::pointer)){# -#}
+            ) : nullptr;
         }
 
         void destroy_current()
@@ -174,17 +178,6 @@
 {%- endfor %}
         }
 
-        std::size_t tag_;
-
-        union
-        {
-{%- for field in composite_type.fields_except_padding %}
-            {{ field.doc | block_comment('cpp-doxygen', 12, 120) }}
-            std::aligned_storage<sizeof({{ field.data_type | declaration }}), alignof({{ field.data_type | declaration }})>::type {{ field.name | id }};
-{%- endfor %}
-        } internal_union_value_;
-
-        void* storage_index_[{{ composite_type.fields_except_padding  | length }}];
     };
 
     VariantType union_value;

--- a/src/nunavut/lang/cpp/templates/_fields_as_union.j2
+++ b/src/nunavut/lang/cpp/templates/_fields_as_union.j2
@@ -106,6 +106,11 @@
             static constexpr const std::size_t {{ field.name | id }} = {{ loop.index0 }}U;
 {%- endfor %}
         };
+        static constexpr const std::size_t MAX_INDEX = {{ composite_type.fields_except_padding  | length }}U;
+
+        size_t index() const{
+            return tag_;
+        }
 
         template<std::size_t I, class...Types> struct alternative;
 

--- a/src/nunavut/lang/cpp/templates/_fields_as_variant.j2
+++ b/src/nunavut/lang/cpp/templates/_fields_as_variant.j2
@@ -21,6 +21,7 @@
             static constexpr const std::size_t {{ field.name | id }} = {{ loop.index0 }}U;
 {%- endfor %}
         };
+        static constexpr const std::size_t MAX_INDEX = {{ composite_type.fields_except_padding  | length }}U;
 
         template<size_t I, typename T>
         struct alternative;
@@ -48,6 +49,7 @@
         {
             return std::get_if<I, Types...>(v);
         }
+
     };
 
     VariantType union_value;

--- a/src/nunavut/lang/cpp/templates/deserialization.j2
+++ b/src/nunavut/lang/cpp/templates/deserialization.j2
@@ -1,0 +1,146 @@
+{#-
+ # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ # Copyright (C) 2020  UAVCAN Development Team  <uavcan.org>
+ # This software is distributed under the terms of the MIT License.
+ # Authors: David Lenfesty, Scott Dixon <dixonsco@amazon.com>, Pavel Kirienko <pavel@uavcan.org>,
+ #          Peter van der Perk <peter.vanderperk@nxp.com>
+-#}
+
+{% from '_definitions.j2' import assert, LITTLE_ENDIAN %}
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro deserialize(t) %}
+{% if t.inner_type.bit_length_set.max > 0 %}
+    {{ _deserialize_impl(t) }}
+{% else %}
+    (void)(in_buffer);
+    return 0;
+{% endif %}
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _deserialize_impl(t) %}
+    const auto capacity_bits = in_buffer.size();
+{% if t.inner_type is StructureType %}
+    {% for f, offset in t.inner_type.iterate_fields_with_offsets() %}
+        {%- if loop.first %}
+            {%- assert f.data_type.alignment_requirement <= t.inner_type.alignment_requirement %}
+        {%- else %}
+    {{ _pad_to_alignment(f.data_type.alignment_requirement) }}
+        {%- endif %}
+    // {{ f }}
+    {{ _deserialize_any(f.data_type, (f|id), offset)|trim|remove_blank_lines }}
+    {% endfor %}
+{% elif t.inner_type is UnionType %}
+    // Union tag field: {{ t.inner_type.tag_field_type }}
+    {#{{ _deserialize_integer(t.inner_type.tag_field_type, 'out_obj->_tag_', 0|bit_length_set)|trim|remove_blank_lines }}
+    {% for f, offset in t.inner_type.iterate_fields_with_offsets() %}
+    {{ 'if' if loop.first else 'else if' }} ({{ loop.index0 }}U == out_obj->_tag_)  // {{ f }}
+    {
+        {%- assert f.data_type.alignment_requirement <= (offset.min) %}
+        {{ _deserialize_any(f.data_type, (f|id), offset)|trim|remove_blank_lines|indent }}
+    }
+    {%- endfor %}
+    else
+    {
+        return -nunavut::support::Error::REPRESENTATION_BAD_UNION_TAG;
+    }#}
+{% else %}{% assert False %}
+{% endif %}
+    {{ _pad_to_alignment(t.inner_type.alignment_requirement) }}
+    {{ assert('in_buffer.offset() % 8U == 0U') }}
+    auto _bits_got_ = std::min<{{ typename_unsigned_bit_length }}>(in_buffer.offset(), capacity_bits);
+    {{ assert('capacity_bits >= _bits_got_') }}
+    return { static_cast<{{ typename_unsigned_length }}>(_bits_got_ / 8U) };
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _pad_to_alignment(n_bits) %}
+{%- if n_bits > 1 -%}
+    {%- assert n_bits in (8, 16, 32, 64) -%}
+    in_buffer.align_offset_to<{{ n_bits }}U>();
+{%- endif -%}
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _deserialize_any(t, reference, offset) %}
+{% if t.alignment_requirement > 1 %}
+    {{ assert('in_buffer.offset_alings_to(%dU)'|format(t.alignment_requirement)) }}
+{% endif %}
+{% if offset.is_aligned_at_byte() %}
+    {{ assert('in_buffer.offset_alings_to_byte()') }}
+{% endif %}
+{%   if t is VoidType %}                {{- _deserialize_void                 (t,            offset) }}
+{% elif t is BooleanType %}             {{- _deserialize_boolean              (t, reference, offset) }}
+{% elif t is IntegerType %}             {{- _deserialize_integer              (t, reference, offset) }}
+{% elif t is FloatType %}               {{- _deserialize_float                (t, reference, offset) }}
+{% elif t is FixedLengthArrayType %}    {{- _deserialize_fixed_length_array   (t, reference, offset) }}
+{% elif t is VariableLengthArrayType %} {{- _deserialize_variable_length_array(t, reference, offset) }}
+{% elif t is CompositeType %}           {{- _deserialize_composite            (t, reference, offset) }}
+{% else %}{% assert False %}
+{% endif %}
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _deserialize_void(t, offset) %}
+    in_buffer.add_offset({{ t.bit_length }});
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _deserialize_boolean(t, reference, offset) %}
+    {{ reference }} = in_buffer.getBit();
+    in_buffer.add_offset(1U);
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _deserialize_integer(t, reference, offset) %}
+{% set getter = 'get%s%d'|format('U' if t is UnsignedIntegerType else 'I', t|to_standard_bit_length) %}
+{# Mem-copy optimization is difficult to perform on non-standard-size signed integers because the C standard does
+ # not define a portable way of unsigned-to-signed conversion (but the other way around is well-defined).
+ # See 6.3.1.8 Usual arithmetic conversions, 6.3.1.3 Signed and unsigned integers.
+ # This template can be greatly expanded with additional special cases if needed.
+ #}
+{#{% if offset.is_aligned_at_byte() and t is UnsignedIntegerType and t.bit_length <= 8 %}
+    if ((offset_bits + {{ t.bit_length }}U) <= capacity_bits)
+    {
+        {{ reference }} = buffer[offset_bits / 8U] & {{ 2 ** t.bit_length - 1 }}U;
+    }
+    else
+    {
+        {{ reference }} = 0U;
+    }
+{% else %}}#}
+    {{ reference }} = in_buffer.{{ getter }}({{ t.bit_length }}U);
+{#{% endif %}#}
+    in_buffer.add_offset({{ t.bit_length }}U);
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _deserialize_float(t, reference, offset) %}
+    {# TODO: apply special case optimizations for aligned data and little-endian IEEE754-conformant platforms. #}
+    {{ reference }} = in_buffer.getF{{ t.bit_length }}();
+    in_buffer.add_offset({{ t.bit_length }}U);
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _deserialize_fixed_length_array(t, reference, offset) %}
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _deserialize_variable_length_array(t, reference, offset) %}
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _deserialize_composite(t, reference, offset) %}
+
+{% endmacro %}

--- a/src/nunavut/lang/cpp/templates/deserialization.j2
+++ b/src/nunavut/lang/cpp/templates/deserialization.j2
@@ -137,13 +137,77 @@
 
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _deserialize_fixed_length_array(t, reference, offset) %}
-    (void)({{reference}});
+{# SPECIAL CASE: PACKED BIT ARRAY #}
+{#{% if t.element_type is BooleanType %}
+    nunavutGetBits(&{{ reference }}_bitpacked_[0], &buffer[0], capacity_bytes, offset_bits, {{ t.capacity }}UL);
+    offset_bits += {{ t.capacity }}UL;
+#}
+{# SPECIAL CASE: BYTES-LIKE ARRAY #}
+{#{% elif t.element_type is PrimitiveType and t.element_type.bit_length == 8 and t.element_type is zero_cost_primitive %}
+    nunavutGetBits(&{{ reference }}[0], &buffer[0], capacity_bytes, offset_bits, {{ t.capacity }}UL * 8U);
+    offset_bits += {{ t.capacity }}UL * 8U;
+#}
+{# SPECIAL CASE: ZERO-COST PRIMITIVES #}
+{#{% elif t.element_type is PrimitiveType and t.element_type is zero_cost_primitive %}
+    {% if t.element_type is FloatType %}
+    static_assert(NUNAVUT_PLATFORM_IEEE754_FLOAT, "Native IEEE754 binary32 required. TODO: relax constraint");
+        {% if t.element_type.bit_length > 32 %}
+    static_assert(NUNAVUT_PLATFORM_IEEE754_DOUBLE, "Native IEEE754 binary64 required. TODO: relax constraint");
+        {% endif %}
+    {% endif %}
+    nunavutGetBits(&{{ reference }}[0], &buffer[0], capacity_bytes, offset_bits, {# -#}
+{#                   {{ t.capacity }}UL * {{ t.element_type.bit_length }}U);
+    offset_bits += {{ t.capacity }}UL * {{ t.element_type.bit_length }}U;
+#}
+{# GENERAL CASE #}
+{#{% else %}#}
+    {# Element offset is the superposition of each individual element offset plus the array's own offset.
+     # For example, an array like uint8[3] offset by 16 bits would have its element_offset = {16, 24, 32}.
+     # We can also unroll element deserialization for small arrays (e.g., below ~10 elements) to take advantage of
+     # spurious alignment of elements but the benefit of such optimization is believed to be negligible. #}
+    {% set element_offset = offset + t.element_type.bit_length_set.repeat_range(t.capacity - 1) %}
+    {% set ref_index = 'index'|to_template_unique_name %}
+    for (size_t {{ ref_index }} = 0U; {{ ref_index }} < {{ t.capacity }}UL; ++{{ ref_index }})
+    {
+        {{ _deserialize_any(t.element_type, reference + ('[%s]'|format(ref_index)), element_offset)|trim|indent }}
+    }
+    {# Size cannot be checked here because if implicit zero extension rule is applied it won't match. #}
+{#{% endif %}#}
 {% endmacro %}
 
 
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _deserialize_variable_length_array(t, reference, offset) %}
-    (void)({{reference}});
+    {
+        {# DESERIALIZE THE IMPLICIT ARRAY LENGTH FIELD #}
+        {% set ref_size = 'size'|to_template_unique_name %}
+        // Array length prefix: {{ t.length_field_type }}
+        {{ _deserialize_integer(t.length_field_type, ('const %s %s'|format((t.length_field_type | declaration), ref_size)) , offset) }}
+        if ( {{ ref_size}} > {{ t.capacity }}U)
+        {
+            return -nunavut::support::Error::REPRESENTATION_BAD_ARRAY_LENGTH;
+        }
+        {{ reference }}.resize({{ ref_size }});
+
+{# COMPUTE THE ARRAY ELEMENT OFFSETS #}
+{# NOTICE: The offset is no longer valid at this point because we just emitted the array length prefix. #}
+{% set element_offset = offset + t.bit_length_set %}
+{% set first_element_offset = offset + t.length_field_type.bit_length %}
+{% assert (element_offset.min) == (first_element_offset.min) %}
+{% if first_element_offset.is_aligned_at_byte() %}
+    {{ assert('in_buffer.offset_alings_to_byte()') }}
+{% endif %}
+    {# GENERAL CASE #}
+    {% set ref_index = 'index'|to_template_unique_name %}
+        for (size_t {{ ref_index }} = 0U; {{ ref_index }} < {{ reference }}.size(); ++{{ ref_index }})
+        {
+            {{
+                _deserialize_any(t.element_type, reference + ('[%s]'|format(ref_index)), element_offset)
+            |trim|indent
+            }}
+        }
+
+    }
 {% endmacro %}
 
 

--- a/src/nunavut/lang/cpp/templates/deserialization.j2
+++ b/src/nunavut/lang/cpp/templates/deserialization.j2
@@ -34,22 +34,27 @@
     {% endfor %}
 {% elif t.inner_type is UnionType %}
     // Union tag field: {{ t.inner_type.tag_field_type }}
-    {#{{ _deserialize_integer(t.inner_type.tag_field_type, 'out_obj->_tag_', 0|bit_length_set)|trim|remove_blank_lines }}
+    {% set ref_index = 'index'|to_template_unique_name %}
+    auto {{ ref_index }} = union_value.index();
+    {{ _deserialize_integer(t.inner_type.tag_field_type, ref_index, 0|bit_length_set)|trim|remove_blank_lines }}
     {% for f, offset in t.inner_type.iterate_fields_with_offsets() %}
-    {{ 'if' if loop.first else 'else if' }} ({{ loop.index0 }}U == out_obj->_tag_)  // {{ f }}
+    {{ 'if' if loop.first else 'else if' }} (VariantType::IndexOf::{{ f| id }} == {{ ref_index }})
     {
+        set_{{ f| id }}();
+        {% set ref_ptr = 'ptr'|to_template_unique_name %}
+        auto {{ ref_ptr }} = get_{{ f| id }}_if();
         {%- assert f.data_type.alignment_requirement <= (offset.min) %}
-        {{ _deserialize_any(f.data_type, (f|id), offset)|trim|remove_blank_lines|indent }}
+        {{ _deserialize_any(f.data_type, '(*%s)' | format(ref_ptr), offset)|trim|remove_blank_lines|indent }}
     }
     {%- endfor %}
     else
     {
         return -nunavut::support::Error::REPRESENTATION_BAD_UNION_TAG;
-    }#}
+    }
 {% else %}{% assert False %}
 {% endif %}
     {{ _pad_to_alignment(t.inner_type.alignment_requirement) }}
-    {{ assert('in_buffer.offset() % 8U == 0U') }}
+    {{ assert('in_buffer.offset_alings_to_byte()') }}
     auto _bits_got_ = std::min<{{ typename_unsigned_bit_length }}>(in_buffer.offset(), capacity_bits);
     {{ assert('capacity_bits >= _bits_got_') }}
     return { static_cast<{{ typename_unsigned_length }}>(_bits_got_ / 8U) };
@@ -132,15 +137,50 @@
 
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _deserialize_fixed_length_array(t, reference, offset) %}
+    (void)({{reference}});
 {% endmacro %}
 
 
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _deserialize_variable_length_array(t, reference, offset) %}
+    (void)({{reference}});
 {% endmacro %}
 
 
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _deserialize_composite(t, reference, offset) %}
+{% set ref_err        = 'err'        |to_template_unique_name %}
+{% set ref_size_bytes = 'size_bytes' |to_template_unique_name %}
+{% set ref_delimiter  = 'dh' |to_template_unique_name %}
+    {
+        {{ typename_unsigned_length }} {{ ref_size_bytes }} = in_buffer.size() / 8U;
+{% if t is DelimitedType %}
+        // Delimiter header: {{ t.delimiter_header_type }}
+        {{ _deserialize_integer(t.delimiter_header_type, ref_size_bytes, offset)|trim|indent }}
+        if (({{ ref_size_bytes }} * 8U) > in_buffer.size())
+        {
+            return -nunavut::support::Error::REPRESENTATION_BAD_DELIMITER_HEADER;
+        }
+        const {{ typename_unsigned_length }} {{ref_delimiter}} = {{ ref_size_bytes }};
+{% endif %}
 
+        {{ assert('in_buffer.offset_alings_to_byte()') }}
+        {
+            const auto {{ ref_err }} = {{ reference }}.deserialize(in_buffer);
+            if({{ ref_err }}){
+                {{ ref_size_bytes }} = {{ ref_err }}.value();
+            }else{
+                return -{{ ref_err }}.error();
+            }
+        }
+
+{% if t is DelimitedType %}
+        {{ assert('in_buffer.offset_alings_to_byte()') }}
+        // Advance the offset by the size of the delimiter header, even if the nested deserialization routine
+        // consumed fewer bytes of data. This behavior implements the implicit truncation rule for nested objects.
+        in_buffer.add_offset({{ ref_delimiter }} * 8U);
+{% else %}
+        in_buffer.add_offset({{ ref_size_bytes }} * 8U);  // Advance by the size of the nested serialized representation.
+{% endif %}
+    }
 {% endmacro %}

--- a/src/nunavut/lang/cpp/templates/serialization.j2
+++ b/src/nunavut/lang/cpp/templates/serialization.j2
@@ -25,14 +25,14 @@
     const {{ typename_unsigned_length }} capacity_bits = out_buffer.size();
 
 {%- if options.enable_override_variable_array_capacity %}
-#ifndef {{ t | full_reference_name }}_DISABLE_SERIALIZATION_BUFFER_CHECK_
+#ifndef {{ t | full_macro_name }}_DISABLE_SERIALIZATION_BUFFER_CHECK_
 {% endif %}
     if ((static_cast<{{ typename_unsigned_bit_length }}>(capacity_bits)) < {{ t.inner_type.bit_length_set.max }}UL)
     {
         return -nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL;
     }
 {%- if options.enable_override_variable_array_capacity %}
-#endif
+#endif // ndef {{ t | full_macro_name }}_DISABLE_SERIALIZATION_BUFFER_CHECK_
 {% endif %}
 
     // Notice that fields that are not an integer number of bytes long may overrun the space allocated for them

--- a/src/nunavut/lang/cpp/templates/serialization.j2
+++ b/src/nunavut/lang/cpp/templates/serialization.j2
@@ -226,13 +226,93 @@
 
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _serialize_fixed_length_array(t, reference, offset) %}
-    (void)({{reference}});
+{# SPECIAL CASE: PACKED BIT ARRAY #}
+{#{% if t.element_type is BooleanType %}
+    {% if offset.is_aligned_at_byte() %}
+    // Optimization prospect: this item is aligned at the byte boundary, so it is possible to use memmove().
+    {% endif %}
+    nunavutCopyBits(&buffer[0], offset_bits, {{ t.capacity }}UL, &{{ reference }}_bitpacked_[0], 0U);
+    out_buffer.add_offset({{ t.capacity }}UL);
+#}
+{# SPECIAL CASE: BYTES-LIKE ARRAY #}
+{#
+{% elif t.element_type is PrimitiveType and t.element_type.bit_length == 8 and t.element_type is zero_cost_primitive %}
+    {% if offset.is_aligned_at_byte() %}
+    // Optimization prospect: this item is aligned at the byte boundary, so it is possible to use memmove().
+    {% endif %}
+    nunavutCopyBits(&buffer[0], offset_bits, {{ t.capacity }}UL * 8U, &{{ reference }}[0], 0U);
+    out_buffer.add_offset({{ t.capacity }}UL * 8U);
+#}
+{# SPECIAL CASE: ZERO-COST PRIMITIVES #}
+{#
+{% elif t.element_type is PrimitiveType and t.element_type is zero_cost_primitive %}
+    // Saturation code not emitted -- assume the native representation is conformant.
+    {% if t.element_type is FloatType %}
+    static_assert(NUNAVUT_PLATFORM_IEEE754_FLOAT, "Native IEEE754 binary32 required. TODO: relax constraint");
+        {% if t.element_type.bit_length > 32 %}
+    static_assert(NUNAVUT_PLATFORM_IEEE754_DOUBLE, "Native IEEE754 binary64 required. TODO: relax constraint");
+        {% endif %}
+    {% endif %}
+    {% if offset.is_aligned_at_byte() %}
+    // Optimization prospect: this item is aligned at the byte boundary, so it is possible to use memmove().
+    {% endif %}
+    nunavutCopyBits(&buffer[0], offset_bits, {{ t.capacity }}UL * {{ t.element_type.bit_length }}UL, {# -#}
+{#                    &{{ reference }}[0], 0U);
+    out_buffer.add_offset({{ t.capacity }}UL * {{ t.element_type.bit_length }}UL);
+#}
+{# GENERAL CASE #}
+{# {% else %} #}
+    {% set ref_origin_offset = 'origin'|to_template_unique_name %}
+    const {{ typename_unsigned_bit_length }} {{ ref_origin_offset }} = out_buffer.offset();
+    {# Element offset is the superposition of each individual element offset plus the array's own offset.
+     # For example, an array like uint8[3] offset by 16 bits would have its element_offset = {16, 24, 32}.
+     # We can also unroll element deserialization for small arrays (e.g., below ~10 elements) to take advantage of
+     # spurious alignment of elements but the benefit of such optimization is believed to be negligible. #}
+    {% set element_offset = offset + t.element_type.bit_length_set.repeat_range(t.capacity - 1) %}
+    {% set ref_index = 'index'|to_template_unique_name %}
+    for (size_t {{ ref_index }} = 0U; {{ ref_index }} < {{ t.capacity }}UL; ++{{ ref_index }})
+    {
+        {{ _serialize_any(t.element_type, reference + ('[%s]'|format(ref_index)), element_offset)|trim|indent }}
+    }
+    // It is assumed that we know the exact type of the serialized entity, hence we expect the size to match.
+    {% if not t.bit_length_set.fixed_length %}
+    {{ assert('(out_buffer.offset() - %s) >= %sULL'|format(ref_origin_offset, t.bit_length_set.min)) }}
+    {{ assert('(out_buffer.offset() - %s) <= %sULL'|format(ref_origin_offset, t.bit_length_set.max)) }}
+    {% else %}
+    {{ assert('(out_buffer.offset() - %s) == %sULL'|format(ref_origin_offset, t.bit_length_set.max)) }}
+    {% endif %}
+    (void) {{ ref_origin_offset }};
+{# {% endif %} #}
 {% endmacro %}
 
 
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _serialize_variable_length_array(t, reference, offset) %}
-    (void)({{reference}});
+    if ({{ reference }}.size() > {{ t.capacity }})
+    {
+        return -nunavut::support::Error::REPRESENTATION_BAD_ARRAY_LENGTH;
+    }
+    // Array length prefix: {{ t.length_field_type }}
+    {{ _serialize_integer(t.length_field_type, reference + '.size()', offset) }}
+
+{# COMPUTE THE ARRAY ELEMENT OFFSETS #}
+{# NOTICE: The offset is no longer valid at this point because we just emitted the array length prefix. #}
+{% set element_offset = offset + t.bit_length_set %}
+{% set first_element_offset = offset + t.length_field_type.bit_length %}
+{% assert (element_offset.min) == (first_element_offset.min) %}
+{% if first_element_offset.is_aligned_at_byte() %}
+    {{ assert('out_buffer.offset_alings_to_byte()') }}
+{% endif %}
+
+{# GENERAL CASE #}
+    {% set ref_index = 'index'|to_template_unique_name %}
+    for (size_t {{ ref_index }} = 0U; {{ ref_index }} < {{ reference }}.size(); ++{{ ref_index }})
+    {
+        {{
+            _serialize_any(t.element_type, reference + ('[%s]'|format(ref_index)), element_offset)
+           |trim|indent
+        }}
+    }
 {% endmacro %}
 
 
@@ -281,5 +361,5 @@
 {% endif %}
 
     out_buffer.add_offset({{ ref_size_bytes }} * 8U);
-    {{ assert('out_buffer.size() >= 0') }}
+    // {{ assert('out_buffer.size() >= 0') }}
 {% endmacro %}

--- a/src/nunavut/lang/cpp/templates/serialization.j2
+++ b/src/nunavut/lang/cpp/templates/serialization.j2
@@ -50,22 +50,24 @@
     }
     {%- endfor %}
 {% elif t.inner_type is UnionType %}
-{#
+    {% set ref_index = 'index'|to_template_unique_name %}
+    const auto {{ ref_index }} = union_value.index();
     {   // Union tag field: {{ t.inner_type.tag_field_type }}
         {{
-            _serialize_integer(t.inner_type.tag_field_type, 'obj->_tag_', 0|bit_length_set)
+            _serialize_integer(t.inner_type.tag_field_type, ref_index, 0|bit_length_set)
            |trim|remove_blank_lines|indent
         }}
     }
     {% for f, offset in t.inner_type.iterate_fields_with_offsets() %}
-    {{ 'if' if loop.first else 'else if' }} ({{ loop.index0 }}U == obj->_tag_)  // {{ f }}
+    {{ 'if' if loop.first else 'else if' }} (VariantType::IndexOf::{{ f| id }} == {{ ref_index }})
     {
+        {% set ref_ptr = 'ptr'|to_template_unique_name %}
+        auto {{ ref_ptr }} = get_{{ f| id }}_if();
         {%- assert f.data_type.alignment_requirement <= (offset.min) %}
-        {{ _serialize_any(f.data_type, (f|id), offset)|trim|remove_blank_lines|indent }}
+        {{ _serialize_any(f.data_type, '(*%s)' | format(ref_ptr), offset)|trim|remove_blank_lines|indent }}
     }
     {%- endfor %}
     else
-#}
     {
         return -nunavut::support::Error::REPRESENTATION_BAD_UNION_TAG;
     }
@@ -224,14 +226,60 @@
 
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _serialize_fixed_length_array(t, reference, offset) %}
+    (void)({{reference}});
 {% endmacro %}
 
 
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _serialize_variable_length_array(t, reference, offset) %}
+    (void)({{reference}});
 {% endmacro %}
 
 
 {# ----------------------------------------------------------------------------------------------------------------- #}
 {% macro _serialize_composite(t, reference, offset) %}
+{% set ref_subspan          = 'subspan'    |to_template_unique_name %}
+{% set ref_err              = 'err'        |to_template_unique_name %}
+{% set ref_size_bytes       = 'size_bytes' |to_template_unique_name %}
+{% set is_variable_size     = not t.inner_type.bit_length_set.fixed_length %}
+{% set size_bytes           = t.inner_type.bit_length_set.max|bits2bytes_ceil %}
+    {{ typename_unsigned_length }} {{ ref_size_bytes }} = {{ size_bytes }}UL;  // Nested object (max) size, in bytes.
+{# PROLOGUE #}
+{% if t is DelimitedType %}
+    // Reserve space for the delimiter header.
+    auto {{ ref_subspan }} = out_buffer.subspan({{ t.delimiter_header_type.bit_length }}U, {{ ref_size_bytes }} * 8U);
+    {%- if not is_variable_size %}
+        {%- assert size_bytes * 8 == (t.inner_type.bit_length_set.min) == (t.inner_type.bit_length_set.max) %}
+    {%- endif %}
+{% else %}
+    auto {{ ref_subspan }} = out_buffer.subspan(0U, {{ ref_size_bytes }} * 8U);
+{% endif %}
+    if(not {{ ref_subspan }}){
+        return -{{ ref_subspan }}.error();
+    }
+
+{# NESTED OBJECT SERIALIZATION #}
+    {{ assert('%s->offset_alings_to_byte()' | format(ref_subspan)) }}
+    auto {{ ref_err }} = {{ reference }}.serialize({{ ref_subspan }}.value());
+    if (not {{ ref_err }})
+    {
+        return {{ ref_err }};
+    }
+    {{ ref_size_bytes }} = {{ ref_err }}.value();
+    // It is assumed that we know the exact type of the serialized entity, hence we expect the size to match.
+{% if not t.inner_type.bit_length_set.fixed_length %}
+    {{ assert('(%s * 8U) >= %sULL'|format(ref_size_bytes, t.inner_type.bit_length_set.min)) }}
+    {{ assert('(%s * 8U) <= %sULL'|format(ref_size_bytes, t.inner_type.bit_length_set.max)) }}
+{% else %}
+    {{ assert('(%s * 8U) == %sULL'|format(ref_size_bytes, t.inner_type.bit_length_set.max)) }}
+{% endif %}
+
+{# EPILOGUE #}
+{% if t is DelimitedType %}
+    // Jump back to write the delimiter header after the nested object is serialized and its length is known.
+    {{ _serialize_integer(t.delimiter_header_type, ref_size_bytes, offset)|trim }}
+{% endif %}
+
+    out_buffer.add_offset({{ ref_size_bytes }} * 8U);
+    {{ assert('out_buffer.size() >= 0') }}
 {% endmacro %}

--- a/src/nunavut/lang/cpp/templates/serialization.j2
+++ b/src/nunavut/lang/cpp/templates/serialization.j2
@@ -1,0 +1,237 @@
+{#-
+ # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ # Copyright (C) 2022  UAVCAN Development Team  <uavcan.org>
+ # This software is distributed under the terms of the MIT License.
+ # Authors: David Lenfesty, Scott Dixon <dixonsco@amazon.com>, Pavel Kirienko <pavel@uavcan.org>,
+ #          Peter van der Perk <peter.vanderperk@nxp.com>, Pavel Pletenev <cpp.create@gmail.com>
+-#}
+
+{% from '_definitions.j2' import assert, LITTLE_ENDIAN %}
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro serialize(t) %}
+{% if t.inner_type.bit_length_set.max > 0 %}
+    {{ _serialize_impl(t) }}
+{% else %}
+    (void)(out_buffer);
+    return 0U;
+{% endif %}
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _serialize_impl(t) %}
+
+    const {{ typename_unsigned_length }} capacity_bits = out_buffer.size();
+
+{%- if options.enable_override_variable_array_capacity %}
+#ifndef {{ t | full_reference_name }}_DISABLE_SERIALIZATION_BUFFER_CHECK_
+{% endif %}
+    if ((static_cast<{{ typename_unsigned_bit_length }}>(capacity_bits)) < {{ t.inner_type.bit_length_set.max }}UL)
+    {
+        return -nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL;
+    }
+{%- if options.enable_override_variable_array_capacity %}
+#endif
+{% endif %}
+
+    // Notice that fields that are not an integer number of bytes long may overrun the space allocated for them
+    // in the serialization buffer up to the next byte boundary. This is by design and is guaranteed to be safe.
+    {{ assert('out_buffer.offset_alings_to_byte()') }}
+{% if t.inner_type is StructureType %}
+    {%- for f, offset in t.inner_type.iterate_fields_with_offsets() %}
+        {%- if loop.first %}
+            {%- assert f.data_type.alignment_requirement <= t.inner_type.alignment_requirement %}
+        {%- else %}
+    {{ _pad_to_alignment(f.data_type.alignment_requirement)|trim|remove_blank_lines }}
+        {%- endif %}
+    {   // {{ f }}
+        {{ _serialize_any(f.data_type, (f|id), offset)|trim|remove_blank_lines|indent }}
+    }
+    {%- endfor %}
+{% elif t.inner_type is UnionType %}
+{#
+    {   // Union tag field: {{ t.inner_type.tag_field_type }}
+        {{
+            _serialize_integer(t.inner_type.tag_field_type, 'obj->_tag_', 0|bit_length_set)
+           |trim|remove_blank_lines|indent
+        }}
+    }
+    {% for f, offset in t.inner_type.iterate_fields_with_offsets() %}
+    {{ 'if' if loop.first else 'else if' }} ({{ loop.index0 }}U == obj->_tag_)  // {{ f }}
+    {
+        {%- assert f.data_type.alignment_requirement <= (offset.min) %}
+        {{ _serialize_any(f.data_type, (f|id), offset)|trim|remove_blank_lines|indent }}
+    }
+    {%- endfor %}
+    else
+#}
+    {
+        return -nunavut::support::Error::REPRESENTATION_BAD_UNION_TAG;
+    }
+{% else %}{% assert False %}
+{% endif %}
+
+    {{ _pad_to_alignment(t.inner_type.alignment_requirement)|trim|remove_blank_lines }}
+    // It is assumed that we know the exact type of the serialized entity, hence we expect the size to match.
+{% if not t.inner_type.bit_length_set.fixed_length %}
+    {{ assert('out_buffer.offset() >= %sULL'|format(t.inner_type.bit_length_set.min)) }}
+    {{ assert('out_buffer.offset() <= %sULL'|format(t.inner_type.bit_length_set.max)) }}
+{% else %}
+    {{ assert('out_buffer.offset() == %sULL'|format(t.inner_type.bit_length_set.max)) }}
+{% endif %}
+    {{ assert('out_buffer.offset_alings_to_byte()') }}
+    return out_buffer.offset_bytes_ceil();
+
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _pad_to_alignment(n_bits) %}
+{% if n_bits > 1 %}
+    {
+        {% set ref_result = 'result'|to_template_unique_name %}
+        const auto {{ref_result}} = out_buffer.padAndMoveToAlignment({{ n_bits }}U);
+        if(not {{ref_result}}){
+            return -{{ref_result}}.error();
+        }
+    }
+{% endif %}
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _serialize_any(t, reference, offset) %}
+{% if t.alignment_requirement > 1 %}
+    {{ assert('out_buffer.offset_alings_to(%dU)'|format(t.alignment_requirement)) }}
+{% endif %}
+{% if offset.is_aligned_at_byte() %}
+    {{ assert('out_buffer.offset_alings_to_byte()') }}
+{% endif %}
+    {# NOTICE: If this is a delimited type, we will be requiring the buffer to be at least extent-sized.
+     # This is a bit wasteful because when serializing we can often use a smaller buffer. #}
+    {% if t.bit_length_set.max > 0 %}
+    {{ assert('%dULL <= out_buffer.size()'|format(t.bit_length_set.max)) }}
+    {% endif %}
+
+{%   if t is VoidType %}                {{- _serialize_void(t, offset) }}
+{% elif t is BooleanType %}             {{- _serialize_boolean(t, reference, offset) }}
+{% elif t is IntegerType %}             {{- _serialize_integer(t, reference, offset) }}
+{% elif t is FloatType %}               {{- _serialize_float(t, reference, offset) }}
+{% elif t is FixedLengthArrayType %}    {{- _serialize_fixed_length_array(t, reference, offset) }}
+{% elif t is VariableLengthArrayType %} {{- _serialize_variable_length_array(t, reference, offset) }}
+{% elif t is CompositeType %}           {{- _serialize_composite(t, reference, offset) }}
+{% else %}{#{% assert False %}#}
+{% endif %}
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _serialize_void(t, offset) %}
+    {% set ref_result = 'result'|to_template_unique_name %}
+    auto {{ ref_result }} = out_buffer.setZeros({{ t.bit_length }}UL);
+    if(not {{ ref_result }}){
+        return -{{ ref_result }}.error();
+    }
+    out_buffer.add_offset({{ t.bit_length }}UL);
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _serialize_boolean(t, reference, offset) %}
+    {% set ref_result = 'result'|to_template_unique_name %}
+    auto {{ ref_result }} = out_buffer.setBit({{ reference }});
+    if(not {{ ref_result }}){
+        return -{{ ref_result }}.error();
+    }
+    out_buffer.add_offset(1UL);
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _serialize_integer(t, reference, offset) %}
+{% if t is saturated %}
+    {% if not t.standard_bit_length %}
+        {% set ref_value = 'sat'|to_template_unique_name %}
+    {{ t|type_from_primitive }} {{ ref_value }} = {{ reference }};
+        {% if t is UnsignedIntegerType %}
+            {% assert t.inclusive_value_range[0] == 0 %}
+        {% else %}
+    if ({{ ref_value }} < {{ t.inclusive_value_range[0]|literal(t) }})
+    {
+        {{ ref_value }} = {{ t.inclusive_value_range[0]|literal(t) }};
+    }
+        {% endif %}
+    if ({{ ref_value }} > {{ t.inclusive_value_range[1]|literal(t) }})
+    {
+        {{ ref_value }} = {{ t.inclusive_value_range[1]|literal(t) }};
+    }
+    {% else %}
+        {% set ref_value = reference %}
+    // Saturation code not emitted -- native representation matches the serialized representation.
+    {% endif %}
+{% else %}
+    {% set ref_value = reference %}
+{% endif %}
+    {% set ref_result = 'result'|to_template_unique_name %}
+    const auto {{ref_result}} = out_buffer.set{{ 'U' if t is UnsignedIntegerType else 'I' }}xx({#- -#}
+        {{ ref_value }}, {{ t.bit_length }}U);
+    if(not {{ref_result}}){
+        return -{{ref_result}}.error();
+    }
+    out_buffer.add_offset({{ t.bit_length }}U);
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _serialize_float(t, reference, offset) %}
+{% if t is saturated %}
+    {% if t.bit_length not in (32, 64) %}
+        {% set ref_value = 'sat'|to_template_unique_name %}
+    {{ t|type_from_primitive }} {{ ref_value }} = {{ reference }};
+    if (std::isfinite({{ ref_value }}))
+    {
+        if ({{ ref_value }} < {{ t.inclusive_value_range[0]|literal(t) }})
+        {
+            {{ ref_value }} = {{ t.inclusive_value_range[0]|literal(t) }};
+        }
+        if ({{ ref_value }} > {{ t.inclusive_value_range[1]|literal(t) }})
+        {
+            {{ ref_value }} = {{ t.inclusive_value_range[1]|literal(t) }};
+        }
+    }
+    {% elif t.bit_length == 32 %}
+        {% set ref_value = reference %}
+    // Saturation code not emitted -- assume the native representation of float32 is conformant.
+    static_assert(NUNAVUT_PLATFORM_IEEE754_FLOAT, "Native IEEE754 binary32 required. TODO: relax constraint");
+    {% elif t.bit_length == 64 %}
+        {% set ref_value = reference %}
+    // Saturation code not emitted -- assume the native representation of float64 is conformant.
+    static_assert(NUNAVUT_PLATFORM_IEEE754_DOUBLE, "Native IEEE754 binary64 required. TODO: relax constraint");
+    {% else %}{% assert False %}
+    {% endif %}
+{% else %}
+    {% set ref_value = reference %}
+{% endif %}
+    {% set ref_result = 'result'|to_template_unique_name %}
+    auto {{ ref_result }} = out_buffer.setF{{ t.bit_length }}({{ ref_value }});
+    if(not {{ ref_result }}){
+        return -{{ ref_result }}.error();
+    }
+    out_buffer.add_offset({{ t.bit_length }}U);
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _serialize_fixed_length_array(t, reference, offset) %}
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _serialize_variable_length_array(t, reference, offset) %}
+{% endmacro %}
+
+
+{# ----------------------------------------------------------------------------------------------------------------- #}
+{% macro _serialize_composite(t, reference, offset) %}
+{% endmacro %}

--- a/src/nunavut/lang/properties.yaml
+++ b/src/nunavut/lang/properties.yaml
@@ -259,7 +259,8 @@ nunavut.lang.cpp:
         all:
             - '\s+'
             - '[^a-zA-Z0-9_]+'
-            - '_{2,}'
+            - '^_{2,}'
+            - '_{2,}$'
     reserved_token_patterns_by_type:
         all:
             - '^\d{1}'
@@ -308,6 +309,7 @@ nunavut.lang.cpp:
         target_endianness: any
         omit_float_serialization_support: false
         enable_serialization_asserts: false
+        enable_override_variable_array_capacity: false
         std: c++14
         variable_array_type: "std::vector<{TYPE},std::allocator<{TYPE}>>"
 

--- a/src/nunavut/lang/properties.yaml
+++ b/src/nunavut/lang/properties.yaml
@@ -245,6 +245,7 @@ nunavut.lang.c:
         omit_float_serialization_support: false
         enable_serialization_asserts: false
         enable_override_variable_array_capacity: false
+        cast_format: "(({type}) {value})"
 
 nunavut.lang.cpp:
     extension: .hpp
@@ -312,6 +313,8 @@ nunavut.lang.cpp:
         enable_override_variable_array_capacity: false
         std: c++14
         variable_array_type: "std::vector<{TYPE},std::allocator<{TYPE}>>"
+        cast_format: "static_cast<{type}>({value})"
+
 
 nunavut.lang.py:
     extension: .py

--- a/src/nunavut/lang/properties.yaml
+++ b/src/nunavut/lang/properties.yaml
@@ -278,6 +278,8 @@ nunavut.lang.cpp:
         'unsigned_bit_length': 'std::size_t'
         'unsigned_port': 'std::uint16_t'
         'byte': 'uint8_t'
+        'float_32': 'float'
+        'float_64': 'double'
     named_values:
         'true': 'true'
         'false': 'false'

--- a/src/nunavut/lang/properties.yaml
+++ b/src/nunavut/lang/properties.yaml
@@ -277,6 +277,7 @@ nunavut.lang.cpp:
         'unsigned_length': 'std::size_t'
         'unsigned_bit_length': 'std::size_t'
         'unsigned_port': 'std::uint16_t'
+        'byte': 'uint8_t'
     named_values:
         'true': 'true'
         'false': 'false'

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -7,7 +7,7 @@
 .. autodata:: __version__
 """
 
-__version__ = "1.7.3"  #: The version number used in the release of nunavut to pypi.
+__version__ = "1.7.4"  #: The version number used in the release of nunavut to pypi.
 
 
 __license__ = "MIT"

--- a/verification/cpp/suite/test_bitarray.cpp
+++ b/verification/cpp/suite/test_bitarray.cpp
@@ -42,6 +42,33 @@ TEST(BitSpan, SetZeros)
     ASSERT_EQ(srcArray[1], 0x03);
 }
 
+TEST(BitSpan, Subspan)
+{
+    std::array<uint8_t,2> srcArray{ 0xAA, 0xFF };
+    nunavut::support::bitspan sp(srcArray);
+    auto res = sp.subspan(0U, 8U);
+    ASSERT_TRUE(res) << "Error was " << res.error();
+    ASSERT_EQ(0U, res.value().offset());
+    ASSERT_EQ(8U, res.value().size());
+    ASSERT_EQ(0xAAU, res.value().aligned_ref());
+
+    res = sp.subspan(8U, 8U);
+    ASSERT_TRUE(res) << "Error was " << res.error();
+    ASSERT_EQ(0U, res.value().offset());
+    ASSERT_EQ(8U, res.value().size());
+    ASSERT_EQ(0xFFU, res.value().aligned_ref());
+
+    res = sp.subspan(12U, 4U);
+    ASSERT_TRUE(res) << "Error was " << res.error();
+    ASSERT_EQ(4U, res.value().offset());
+    ASSERT_EQ(4U, res.value().size());
+    ASSERT_EQ(0xFFU, res.value().aligned_ref());
+
+    res = sp.subspan(0U, 32U);
+    ASSERT_FALSE(res);
+    ASSERT_EQ(nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL, res.error());
+}
+
 TEST(BitSpan, AlignedPtr) {
     std::array<uint8_t,5> srcArray{ 1, 2, 3, 4, 5 };
     {

--- a/verification/cpp/suite/test_bitarray.cpp
+++ b/verification/cpp/suite/test_bitarray.cpp
@@ -22,7 +22,7 @@ TEST(BitSpan, Constructor) {
         ASSERT_EQ(sp.size(), 5U*8U);
     }
     const uint8_t csrcVar = 0x8F;
-    const std::array<uint8_t,5> csrcArray{ 1, 2, 3, 4, 5 };
+    const std::array<const uint8_t,5> csrcArray{ 1, 2, 3, 4, 5 };
     {
         nunavut::support::const_bitspan sp{{&csrcVar, 1}};
         ASSERT_EQ(sp.size(), 1U*8U);
@@ -72,23 +72,23 @@ TEST(BitSpan, Subspan)
 TEST(BitSpan, AlignedPtr) {
     std::array<uint8_t,5> srcArray{ 1, 2, 3, 4, 5 };
     {
-        auto actualPtr = nunavut::support::bitspan{srcArray}.aligned_ptr();
+        auto actualPtr = nunavut::support::bitspan(srcArray).aligned_ptr();
         ASSERT_EQ(actualPtr, srcArray.data());
     }
     {
-        auto actualPtr = nunavut::support::bitspan{srcArray, 1}.aligned_ptr();
+        auto actualPtr = nunavut::support::bitspan(srcArray, 1).aligned_ptr();
         ASSERT_EQ(actualPtr, srcArray.data());
     }
     {
-        auto actualPtr = nunavut::support::bitspan{srcArray, 5}.aligned_ptr();
+        auto actualPtr = nunavut::support::bitspan(srcArray, 5).aligned_ptr();
         ASSERT_EQ(actualPtr, srcArray.data());
     }
     {
-        auto actualPtr = nunavut::support::bitspan{srcArray, 7}.aligned_ptr();
+        auto actualPtr = nunavut::support::bitspan(srcArray, 7).aligned_ptr();
         ASSERT_EQ(actualPtr, srcArray.data());
     }
     {
-        auto actualPtr = nunavut::support::bitspan{srcArray}.aligned_ptr(8);
+        auto actualPtr = nunavut::support::bitspan(srcArray).aligned_ptr(8);
         ASSERT_EQ(actualPtr, &srcArray[1]);
     }
 }
@@ -103,10 +103,19 @@ TEST(BitSpan, TestSize) {
         nunavut::support::bitspan sp{src, 1};
         ASSERT_EQ(sp.size(), 5U*8U - 1U);
     }
+    std::array<const uint8_t,5> csrc{ 1, 2, 3, 4, 5 };
+    {
+        nunavut::support::const_bitspan sp{csrc};
+        ASSERT_EQ(sp.size(), 5U*8U);
+    }
+    {
+        nunavut::support::const_bitspan sp{csrc, 1};
+        ASSERT_EQ(sp.size(), 5U*8U - 1U);
+    }
 }
 
 TEST(BitSpan, CopyBits) {
-    std::array<uint8_t,5> src{ 1, 2, 3, 4, 5 };
+    std::array<const uint8_t,5> src{ 1, 2, 3, 4, 5 };
     std::array<uint8_t,6> dst{};
     memset(dst.data(), 0, dst.size());
 
@@ -118,7 +127,7 @@ TEST(BitSpan, CopyBits) {
 }
 
 TEST(BitSpan, CopyBitsWithAlignedOffset) {
-    std::array<uint8_t,5> src{ 0x11, 0x22, 0x33, 0x44, 0x55 };
+    std::array<const uint8_t,5> src{ 0x11, 0x22, 0x33, 0x44, 0x55 };
     std::array<uint8_t,6> dst{};
     memset(dst.data(), 0, dst.size());
 
@@ -153,19 +162,19 @@ TEST(BitSpan, CopyBitsWithAlignedOffset) {
 }
 
 TEST(BitSpan, CopyBitsWithAlignedOffsetNonByteLen) {
-    std::array<uint8_t,7> src{ 0x0, 0x0, 0x11, 0x22, 0x33, 0x44, 0x55 };
+    std::array<const uint8_t,7> src{ 0x0, 0x0, 0x11, 0x22, 0x33, 0x44, 0x55 };
     std::array<uint8_t,1> dst{};
     memset(dst.data(), 0, dst.size());
 
-    nunavut::support::const_bitspan(src, 2U * 8U).copyTo(nunavut::support::bitspan{dst}, 4);
+    nunavut::support::const_bitspan({src}, 2U * 8U).copyTo(nunavut::support::bitspan{dst}, 4);
     ASSERT_EQ(0x1U, dst[0]);
 
-    nunavut::support::const_bitspan(src, 3U * 8U).copyTo(nunavut::support::bitspan{dst}, 4);
+    nunavut::support::const_bitspan({src}, 3U * 8U).copyTo(nunavut::support::bitspan{dst}, 4);
     ASSERT_EQ(0x2U, dst[0]);
 }
 
 TEST(BitSpan, CopyBitsWithUnalignedOffset){
-    std::array<uint8_t,6> src{ 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA };
+    std::array<const uint8_t,6> src{ 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA };
     std::array<uint8_t,6> dst{};
     memset(dst.data(), 0, dst.size());
 
@@ -193,7 +202,7 @@ TEST(BitSpan, CopyBitsWithUnalignedOffset){
 TEST(BitSpan, SaturateBufferFragmentBitLength)
 {
     using namespace nunavut::support;
-    std::array<uint8_t, 4> data{};
+    std::array<const uint8_t, 4> data{};
     ASSERT_EQ(32U, const_bitspan(data,  0U).saturateBufferFragmentBitLength(32));
     ASSERT_EQ(31U, const_bitspan(data,  1U).saturateBufferFragmentBitLength(32));
     ASSERT_EQ(16U, const_bitspan(data,  0U).saturateBufferFragmentBitLength(16));
@@ -204,7 +213,7 @@ TEST(BitSpan, SaturateBufferFragmentBitLength)
 
 TEST(BitSpan, GetBits)
 {
-    std::array<uint8_t, 16> src{ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+    std::array<const uint8_t, 16> src{ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
     std::array<uint8_t, 6> dst{};
     memset(dst.data(), 0xAA, dst.size());
     nunavut::support::const_bitspan{{src.data(), 6U}, 0}.getBits(dst, 0);
@@ -305,7 +314,7 @@ TEST(BitSpan, SetIxx_bufferOverflow)
     ASSERT_EQ(0xAA, buffer[2]);
     rc = nunavut::support::bitspan{{buffer, 2U}, 2U*8U}.setIxx(0xAA, 8);
     ASSERT_FALSE(rc);
-    ASSERT_EQ(-nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL, rc);
+    ASSERT_EQ(nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL, rc.error());
     ASSERT_EQ(0xAA, buffer[2]);
 }
 

--- a/verification/cpp/suite/test_bitarray.cpp
+++ b/verification/cpp/suite/test_bitarray.cpp
@@ -753,10 +753,10 @@ TEST(BitSpan, Float16Unpack)
 {
     // >>> hex(int.from_bytes(np.array([-np.float16('3.14')]).tobytes(), 'little'))
     // '0xc248'
-    ASSERT_NEAR(-3.14f, nunavut::support::float16Unpack(0xC248), 0.001f);
+    ASSERT_TRUE(CompareFloatsNear(-3.14f, nunavut::support::float16Unpack(0xC248), 0.001f));
     // >>> hex(int.from_bytes(np.array([np.float16('3.14')]).tobytes(), 'little'))
     // '0x4248'
-    ASSERT_NEAR(3.14f, nunavut::support::float16Unpack(0x4248), 0.001f);
+    ASSERT_TRUE(CompareFloatsNear(3.14f, nunavut::support::float16Unpack(0x4248), 0.001f));
     // >>> hex(int.from_bytes(np.array([np.float16('nan')]).tobytes(), 'little'))
     // '0x7e00'
     ASSERT_TRUE(std::isnan(nunavut::support::float16Unpack(0x7e00)));
@@ -765,16 +765,16 @@ TEST(BitSpan, Float16Unpack)
     ASSERT_TRUE(std::isnan(nunavut::support::float16Unpack(0xfe00)));
     // >>> hex(int.from_bytes(np.array([np.float16('infinity')]).tobytes(), 'little'))
     // '0x7c00'
-    ASSERT_FLOAT_EQ(INFINITY, nunavut::support::float16Unpack(0x7c00));
+    ASSERT_FLOAT_EQ(std::numeric_limits<float>::infinity(), nunavut::support::float16Unpack(0x7c00));
     // >>> hex(int.from_bytes(np.array([-np.float16('infinity')]).tobytes(), 'little'))
     // '0xfc00'
-    ASSERT_FLOAT_EQ(-INFINITY, nunavut::support::float16Unpack(0xfc00));
+    ASSERT_FLOAT_EQ(-std::numeric_limits<float>::infinity(), nunavut::support::float16Unpack(0xfc00));
 }
 
 TEST(BitSpan, Float16Unpack_INFINITY)
 {
-    ASSERT_FLOAT_EQ(INFINITY, nunavut::support::float16Unpack(0x7C00));
-    ASSERT_FLOAT_EQ(-INFINITY, nunavut::support::float16Unpack(0xFC00));
+    ASSERT_FLOAT_EQ(std::numeric_limits<float>::infinity(), nunavut::support::float16Unpack(0x7C00));
+    ASSERT_FLOAT_EQ(-std::numeric_limits<float>::infinity(), nunavut::support::float16Unpack(0xFC00));
 }
 
 // +--------------------------------------------------------------------------+
@@ -817,8 +817,8 @@ TEST(BitSpan, Float16PackUnpack)
     ASSERT_TRUE(helperPackUnpack(*(reinterpret_cast<const float*>(&signalling_nan_bits)), 0xFF00, 10));
     ASSERT_TRUE(helperPackUnpack(*(reinterpret_cast<const float*>(&signalling_negative_nan_bits)), 0xFF00, 10));
 #pragma GCC diagnostic pop
-    ASSERT_TRUE(helperPackUnpack(INFINITY, 0xFF00, 10));
-    ASSERT_TRUE(helperPackUnpack(-INFINITY, 0xFF00, 10));
+    ASSERT_TRUE(helperPackUnpack(std::numeric_limits<float>::infinity(), 0xFF00, 10));
+    ASSERT_TRUE(helperPackUnpack(-std::numeric_limits<float>::infinity(), 0xFF00, 10));
 }
 
 TEST(BitSpan, Float16PackUnpack_NAN)
@@ -853,7 +853,7 @@ TEST(BitSpan, Get16)
     // '0x4248'
     const uint8_t buf[3] = {0x48, 0x42, 0x00};
     const float result = nunavut::support::const_bitspan{ { buf, sizeof(buf) } }.getF16( );
-    ASSERT_NEAR(3.14f, result, 0.001f);
+    ASSERT_TRUE(CompareFloatsNear(3.14f, result, 0.001f));
 }
 
 
@@ -905,11 +905,11 @@ TEST(BitSpan, SetF32)
 
     memset(buffer, 0, sizeof(buffer));
     nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF32( INFINITY);
-    helperAssertSerFloat32SameAsIEEE(INFINITY, buffer);
+    helperAssertSerFloat32SameAsIEEE(std::numeric_limits<float>::infinity(), buffer);
 
     memset(buffer, 0, sizeof(buffer));
     nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF32( -INFINITY);
-    helperAssertSerFloat32SameAsIEEE(-INFINITY, buffer);
+    helperAssertSerFloat32SameAsIEEE(-std::numeric_limits<float>::infinity(), buffer);
 }
 
 // +--------------------------------------------------------------------------+
@@ -922,13 +922,13 @@ TEST(BitSpan, GetF32)
     // '0xff800000'
     const uint8_t buffer_neg_inf[] = {0x00, 0x00, 0x80, 0xFF};
     float result = nunavut::support::const_bitspan{ { buffer_neg_inf, sizeof(buffer_neg_inf) } }.getF32( );
-    ASSERT_FLOAT_EQ(-INFINITY, result);
+    ASSERT_FLOAT_EQ(-std::numeric_limits<float>::infinity(), result);
 
     // >>> hex(int.from_bytes(np.array([np.float32('infinity')]).tobytes(), 'little'))
     // '0x7f800000'
     const uint8_t buffer_inf[] = {0x00, 0x00, 0x80, 0x7F};
     result = nunavut::support::const_bitspan{ { buffer_inf, sizeof(buffer_inf) } }.getF32( );
-    ASSERT_FLOAT_EQ(INFINITY, result);
+    ASSERT_FLOAT_EQ(std::numeric_limits<float>::infinity(), result);
 
     // >>> hex(int.from_bytes(np.array([np.float32('nan')]).tobytes(), 'little'))
     // '0x7fc00000'
@@ -960,13 +960,13 @@ TEST(BitSpan, GetF64)
     // '0x7ff0000000000000'
     const uint8_t buffer_inf[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F};
     result = nunavut::support::const_bitspan{ { buffer_inf, sizeof(buffer_inf) } }.getF64( );
-    ASSERT_DOUBLE_EQ(INFINITY, result);
+    ASSERT_DOUBLE_EQ(std::numeric_limits<double>::infinity(), result);
 
     // >>> hex(int.from_bytes(np.array([-np.float64('infinity')]).tobytes(), 'little'))
     // '0xfff0000000000000'
     const uint8_t buffer_neg_inf[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xFF};
     result = nunavut::support::const_bitspan{ { buffer_neg_inf, sizeof(buffer_neg_inf) } }.getF64( );
-    ASSERT_DOUBLE_EQ(-INFINITY, result);
+    ASSERT_DOUBLE_EQ(-std::numeric_limits<double>::infinity(), result);
 
     // >>> hex(int.from_bytes(np.array([np.float64('nan')]).tobytes(), 'little'))
     // '0x7ff8000000000000'
@@ -1019,18 +1019,18 @@ TEST(BitSpan, SetF64)
     ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(-3.141592653589793, buffer));
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( -NAN);
-    ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(-NAN, buffer));
+    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( -std::numeric_limits<double>::quiet_NaN());
+    ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(-std::numeric_limits<double>::quiet_NaN(), buffer));
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( NAN);
-    ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(NAN, buffer));
+    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( std::numeric_limits<double>::quiet_NaN());
+    ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(std::numeric_limits<double>::quiet_NaN(), buffer));
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( INFINITY);
-    ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(INFINITY, buffer));
+    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( std::numeric_limits<double>::infinity());
+    ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(std::numeric_limits<double>::infinity(), buffer));
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( -INFINITY);
-    ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(-INFINITY, buffer));
+    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( -std::numeric_limits<double>::infinity());
+    ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(-std::numeric_limits<double>::infinity(), buffer));
 }

--- a/verification/cpp/suite/test_bitarray.cpp
+++ b/verification/cpp/suite/test_bitarray.cpp
@@ -1,0 +1,462 @@
+#include "gmock/gmock.h"
+#include "nunavut/support/serialization.hpp"
+
+
+TEST(BitSpan, Constructor) {
+    uint8_t srcVar = 0x8F;
+    std::array<uint8_t,5> srcArray{ 1, 2, 3, 4, 5 };
+    {
+        nunavut::support::bitspan sp{{&srcVar, 1}};
+        ASSERT_EQ(sp.size(), 1U*8U);
+    }
+    {
+        nunavut::support::bitspan sp{srcArray};
+        ASSERT_EQ(sp.size(), 5U*8U);
+    }
+    const uint8_t csrcVar = 0x8F;
+    const std::array<uint8_t,5> csrcArray{ 1, 2, 3, 4, 5 };
+    {
+        nunavut::support::const_bitspan sp{{&csrcVar, 1}};
+        ASSERT_EQ(sp.size(), 1U*8U);
+    }
+    {
+        nunavut::support::const_bitspan sp{csrcArray};
+        ASSERT_EQ(sp.size(), 5U*8U);
+    }
+}
+
+TEST(BitSpan, AlignedPtr) {
+    std::array<uint8_t,5> srcArray{ 1, 2, 3, 4, 5 };
+    {
+        auto actualPtr = nunavut::support::bitspan{srcArray}.aligned_ptr();
+        ASSERT_EQ(actualPtr, srcArray.data());
+    }
+    {
+        auto actualPtr = nunavut::support::bitspan{srcArray, 1}.aligned_ptr();
+        ASSERT_EQ(actualPtr, srcArray.data());
+    }
+    {
+        auto actualPtr = nunavut::support::bitspan{srcArray, 5}.aligned_ptr();
+        ASSERT_EQ(actualPtr, srcArray.data());
+    }
+    {
+        auto actualPtr = nunavut::support::bitspan{srcArray, 7}.aligned_ptr();
+        ASSERT_EQ(actualPtr, srcArray.data());
+    }
+    {
+        auto actualPtr = nunavut::support::bitspan{srcArray}.aligned_ptr(8);
+        ASSERT_EQ(actualPtr, &srcArray[1]);
+    }
+}
+
+TEST(BitSpan, TestSize) {
+    std::array<uint8_t,5> src{ 1, 2, 3, 4, 5 };
+    {
+        nunavut::support::bitspan sp{src};
+        ASSERT_EQ(sp.size(), 5U*8U);
+    }
+    {
+        nunavut::support::bitspan sp{src, 1};
+        ASSERT_EQ(sp.size(), 5U*8U - 1U);
+    }
+}
+
+TEST(BitSpan, CopyBits) {
+    std::array<uint8_t,5> src{ 1, 2, 3, 4, 5 };
+    std::array<uint8_t,6> dst{};
+    memset(dst.data(), 0, dst.size());
+
+    nunavut::support::const_bitspan sp{src};
+    nunavut::support::bitspan dstSp{dst};
+    sp.copyTo(dstSp);
+    for(size_t i = 0; i < src.size(); ++i)
+    {
+        ASSERT_EQ(src[i], dst[i]);
+    }
+}
+
+TEST(BitSpan, CopyBitsWithAlignedOffset) {
+    std::array<uint8_t,5> src{ 1, 2, 3, 4, 5 };
+    std::array<uint8_t,6> dst{};
+    memset(dst.data(), 0, dst.size());
+
+    nunavut::support::const_bitspan{src, 8}.copyTo(nunavut::support::bitspan{dst});
+
+    for(size_t i = 0; i < src.size() - 1; ++i)
+    {
+        ASSERT_EQ(src[i + 1], dst[i]);
+    }
+    ASSERT_EQ(0, dst[dst.size() - 1]);
+
+    memset(dst.data(), 0, dst.size());
+
+    nunavut::support::const_bitspan{src, 0}.copyTo(nunavut::support::bitspan{dst, 8});
+
+    for(size_t i = 0; i < src.size() - 1; ++i)
+    {
+        ASSERT_EQ(src[i], dst[i+1]);
+    }
+    ASSERT_EQ(0, dst[0]);
+}
+
+TEST(BitSpan, CopyBitsWithUnalignedOffset){
+    std::array<uint8_t,6> src{ 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA };
+    std::array<uint8_t,6> dst{};
+    memset(dst.data(), 0, dst.size());
+
+    nunavut::support::const_bitspan{src, 1}.copyTo(
+        nunavut::support::bitspan{dst, 0}, (src.size()-1)*8U);
+    for(size_t i = 0; i < src.size() - 1; ++i)
+    {
+        ASSERT_EQ(0x55, dst[i]);
+    }
+    ASSERT_EQ(0x00, dst[dst.size() - 1]);
+
+    memset(dst.data(), 0, dst.size());
+
+    nunavut::support::const_bitspan{src}.copyTo(
+        nunavut::support::bitspan{dst, 1}, 8U * (src.size() - 1));
+
+    for(size_t i = 0; i < src.size() - 1; ++i)
+    {
+        ASSERT_EQ((i == 0) ? 0x54 : 0x55, dst[i]);
+    }
+    ASSERT_EQ(0x54, dst[0]);
+}
+
+
+TEST(BitSpan, SaturateBufferFragmentBitLength)
+{
+    using namespace nunavut::support;
+    std::array<uint8_t, 4> data{};
+    ASSERT_EQ(32U, const_bitspan(data,  0U).saturateBufferFragmentBitLength(32));
+    ASSERT_EQ(31U, const_bitspan(data,  1U).saturateBufferFragmentBitLength(32));
+    ASSERT_EQ(16U, const_bitspan(data,  0U).saturateBufferFragmentBitLength(16));
+    ASSERT_EQ(15U, const_bitspan(data, 17U).saturateBufferFragmentBitLength(24));
+    ASSERT_EQ(0U,  const_bitspan({data.data(), 2}, 24U).saturateBufferFragmentBitLength(24));
+}
+
+
+TEST(BitSpan, GetBits)
+{
+    std::array<uint8_t, 16> src{ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+    std::array<uint8_t, 6> dst{};
+    memset(dst.data(), 0xAA, dst.size());
+    nunavut::support::const_bitspan{{src.data(), 6U}, 0}.getBits(dst, 0);
+    ASSERT_EQ(0xAA, dst[0]);   // no bytes copied
+    ASSERT_EQ(0xAA, dst[1]);
+    ASSERT_EQ(0xAA, dst[2]);
+    ASSERT_EQ(0xAA, dst[3]);
+    ASSERT_EQ(0xAA, dst[4]);
+    ASSERT_EQ(0xAA, dst[5]);
+
+    nunavut::support::const_bitspan{{src.data(), 0U}, 0}.getBits(dst, 4U*8U);
+    ASSERT_EQ(0x00, dst[0]);   // all bytes zero-extended
+    ASSERT_EQ(0x00, dst[1]);
+    ASSERT_EQ(0x00, dst[2]);
+    ASSERT_EQ(0x00, dst[3]);
+    ASSERT_EQ(0xAA, dst[4]);
+    ASSERT_EQ(0xAA, dst[5]);
+
+    memset(dst.data(), 0xAA, dst.size());
+    nunavut::support::const_bitspan{{src.data(), 6}, 6U*8U}.getBits(dst, 4U*8U);
+    ASSERT_EQ(0x00, dst[0]);   // all bytes zero-extended
+    ASSERT_EQ(0x00, dst[1]);
+    ASSERT_EQ(0x00, dst[2]);
+    ASSERT_EQ(0x00, dst[3]);
+    ASSERT_EQ(0xAA, dst[4]);
+    ASSERT_EQ(0xAA, dst[5]);
+
+    memset(dst.data(), 0xAA, dst.size());
+    nunavut::support::const_bitspan{{src.data(), 6U}, 5U*8U}.getBits(dst, 4U*8U);
+    ASSERT_EQ(0x66, dst[0]);   // one byte copied
+    ASSERT_EQ(0x00, dst[1]);   // the rest are zero-extended
+    ASSERT_EQ(0x00, dst[2]);
+    ASSERT_EQ(0x00, dst[3]);
+    ASSERT_EQ(0xAA, dst[4]);
+    ASSERT_EQ(0xAA, dst[5]);
+
+    memset(dst.data(), 0xAA, dst.size());
+    nunavut::support::const_bitspan{{src.data(), 6}, 4U * 8U + 4U}.getBits(dst, 4U*8U);
+    ASSERT_EQ(0x65, dst[0]);   // one-and-half bytes are copied
+    ASSERT_EQ(0x06, dst[1]);   // the rest are zero-extended
+    ASSERT_EQ(0x00, dst[2]);
+    ASSERT_EQ(0x00, dst[3]);
+    ASSERT_EQ(0xAA, dst[4]);
+    ASSERT_EQ(0xAA, dst[5]);
+
+    memset(dst.data(), 0xAA, dst.size());
+    nunavut::support::const_bitspan{{src.data(), 7}, 4U}.getBits(dst, 4U*8U);
+    ASSERT_EQ(0x21, dst[0]);   // all bytes are copied offset by half
+    ASSERT_EQ(0x32, dst[1]);
+    ASSERT_EQ(0x43, dst[2]);
+    ASSERT_EQ(0x54, dst[3]);
+    ASSERT_EQ(0xAA, dst[4]);
+    ASSERT_EQ(0xAA, dst[5]);
+
+    memset(dst.data(), 0xAA, dst.size());
+    nunavut::support::const_bitspan{{src.data(), 7}, 4U}.getBits(dst, 3U*8U + 4U);
+    ASSERT_EQ(0x21, dst[0]);   // 28 bits are copied
+    ASSERT_EQ(0x32, dst[1]);
+    ASSERT_EQ(0x43, dst[2]);
+    ASSERT_EQ(0x04, dst[3]);   // the last bits of the last byte are zero-padded out
+    ASSERT_EQ(0xAA, dst[4]);
+    ASSERT_EQ(0xAA, dst[5]);
+}
+
+TEST(BitSpan, SetIxx_neg1)
+{
+    uint8_t data[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    auto res = nunavut::support::bitspan{data}.setIxx(-1, sizeof(data) * 8);
+    ASSERT_TRUE(res);
+    for (size_t i = 0; i < sizeof(data); ++i)
+    {
+        ASSERT_EQ(0xFF, data[i]);
+    }
+}
+
+TEST(BitSpan, SetIxx_neg255)
+{
+    uint8_t data[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    nunavut::support::bitspan{data}.setIxx(-255, sizeof(data) * 8);
+    ASSERT_EQ(0xFF, data[1]);
+    ASSERT_EQ(0x01, data[0]);
+}
+
+TEST(BitSpan, SetIxx_neg255_tooSmall)
+{
+    uint8_t data[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    nunavut::support::bitspan{data}.setIxx(-255, sizeof(data) * 1);
+    ASSERT_EQ(0x00, data[1]);
+    ASSERT_EQ(0x01, data[0]);
+}
+
+TEST(BitSpan, SetIxx_bufferOverflow)
+{
+    uint8_t buffer[] = {0x00, 0x00, 0x00};
+
+    auto rc = nunavut::support::bitspan{{buffer, 3U}, 2U*8U}.setIxx(0xAA, 8);
+    ASSERT_TRUE(rc);
+    ASSERT_EQ(0xAA, buffer[2]);
+    rc = nunavut::support::bitspan{{buffer, 2U}, 2U*8U}.setIxx(0xAA, 8);
+    ASSERT_FALSE(rc);
+    ASSERT_EQ(-nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL, rc);
+    ASSERT_EQ(0xAA, buffer[2]);
+}
+
+// +--------------------------------------------------------------------------+
+// | nunavut[Get|Set]Bit
+// +--------------------------------------------------------------------------+
+
+TEST(BitSpan, SetBit)
+{
+    uint8_t buffer[] = {0x00};
+    nunavut::support::bitspan sp{{buffer, sizeof(buffer)}};
+
+    auto res = sp.setBit(true);
+    ASSERT_TRUE(res);
+    ASSERT_EQ(0x01, buffer[0]);
+    res = sp.setBit(false);
+    ASSERT_TRUE(res);
+    ASSERT_EQ(0x00, buffer[0]);
+    res = sp.setBit(true);
+    ASSERT_TRUE(res);
+    res = sp.at_offset(1).setBit(true);
+    ASSERT_TRUE(res);
+    ASSERT_EQ(0x03, buffer[0]);
+}
+
+TEST(BitSpan, SetBit_bufferOverflow)
+{
+    uint8_t buffer[] = {0x00, 0x00};
+
+    auto res = nunavut::support::bitspan{{buffer, 1U}, 8}.setBit(true);
+
+    ASSERT_FALSE(res.has_value());
+    ASSERT_EQ(nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL, res.error());
+    ASSERT_EQ(0x00, buffer[1]);
+}
+
+TEST(BitSpan, GetBit)
+{
+    const uint8_t buffer[] = {0x01};
+    nunavut::support::const_bitspan sp{{buffer, 1U}, 0};
+    ASSERT_EQ(true, sp.getBit());
+    ASSERT_EQ(false, sp.at_offset(1).getBit());
+}
+
+// +--------------------------------------------------------------------------+
+// | nunavutGetU8
+// +--------------------------------------------------------------------------+
+
+TEST(BitSpan, GetU8)
+{
+    const uint8_t data[] = {0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    ASSERT_EQ(0xFE, nunavut::support::const_bitspan(data, 0).getU8(8U));
+}
+
+TEST(BitSpan, GetU8_tooSmall)
+{
+    const uint8_t data[] = {0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    ASSERT_EQ(0x7F, nunavut::support::const_bitspan(data, 0).getU8(7U));
+}
+
+// +--------------------------------------------------------------------------+
+// | nunavutGetU16
+// +--------------------------------------------------------------------------+
+
+TEST(BitSpan, GetU16)
+{
+    const uint8_t data[] = {0xAA, 0xAA};
+    ASSERT_EQ(0xAAAAU, nunavut::support::const_bitspan(data, 0).getU16(16U));
+}
+
+TEST(BitSpan, GetU16_tooSmall)
+{
+    const uint8_t data[] = {0xAA, 0xAA};
+    ASSERT_EQ(0x0055U, nunavut::support::const_bitspan(data, 9).getU16(16U));
+}
+
+// +--------------------------------------------------------------------------+
+// | nunavutGetU32
+// +--------------------------------------------------------------------------+
+
+TEST(BitSpan, GetU32)
+{
+    const uint8_t data[] = {0xAA, 0xAA, 0xAA, 0xAA};
+    ASSERT_EQ(0xAAAAAAAAU, nunavut::support::const_bitspan(data, 0).getU32(32U));
+}
+
+TEST(BitSpan, GetU32_tooSmall)
+{
+    const uint8_t data[] = {0xAA, 0xAA, 0xAA, 0xAA};
+    ASSERT_EQ(0x00555555U, nunavut::support::const_bitspan(data, 9).getU32(32U));
+}
+
+// +--------------------------------------------------------------------------+
+// | nunavutGetU64
+// +--------------------------------------------------------------------------+
+
+TEST(BitSpan, GetU64)
+{
+    const uint8_t data[] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+    ASSERT_EQ(0xAAAAAAAAAAAAAAAAU, nunavut::support::const_bitspan(data, 0).getU64(64U));
+}
+
+TEST(BitSpan, GetU64_tooSmall)
+{
+    const uint8_t data[] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+    ASSERT_EQ(0x0055555555555555U, nunavut::support::const_bitspan(data, 9).getU64(64U));
+}
+
+// +--------------------------------------------------------------------------+
+// | nunavutGetI8
+// +--------------------------------------------------------------------------+
+
+TEST(BitSpan, GetI8)
+{
+    const uint8_t data[] = {0xFF};
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI8(8U));
+}
+
+TEST(BitSpan, GetI8_tooSmall)
+{
+    const uint8_t data[] = {0xFF};
+    ASSERT_EQ(127, nunavut::support::const_bitspan(data, 1).getI8(8U));
+}
+
+TEST(BitSpan, GetI8_tooSmallAndNegative)
+{
+    const uint8_t data[] = {0xFF};
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI8(4U));
+}
+
+TEST(BitSpan, GetI8_zeroDataLen)
+{
+    const uint8_t data[] = {0xFF};
+    ASSERT_EQ(0, nunavut::support::const_bitspan(data, 0).getI8(0U));
+}
+
+// +--------------------------------------------------------------------------+
+// | nunavutGetI16
+// +--------------------------------------------------------------------------+
+
+TEST(BitSpan, GetI16)
+{
+    const uint8_t data[] = {0xFF, 0xFF};
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI16(16U));
+}
+
+TEST(BitSpan, GetI16_tooSmall)
+{
+    const uint8_t data[] = {0xFF, 0xFF};
+    ASSERT_EQ(32767, nunavut::support::const_bitspan(data, 1).getI16(16U));
+}
+
+TEST(BitSpan, GetI16_tooSmallAndNegative)
+{
+    const uint8_t data[] = {0xFF, 0xFF};
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI16(12U));
+}
+
+TEST(BitSpan, GetI16_zeroDataLen)
+{
+    const uint8_t data[] = {0xFF, 0xFF};
+    ASSERT_EQ(0, nunavut::support::const_bitspan(data, 0).getI16(0U));
+}
+
+// +--------------------------------------------------------------------------+
+// | nunavutGetI32
+// +--------------------------------------------------------------------------+
+
+TEST(BitSpan, GetI32)
+{
+    const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF};
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI32(32U));
+}
+
+TEST(BitSpan, GetI32_tooSmall)
+{
+    const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF};
+    ASSERT_EQ(2147483647, nunavut::support::const_bitspan(data, 1).getI32(32U));
+}
+
+TEST(BitSpan, GetI32_tooSmallAndNegative)
+{
+    const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF};
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI32(20U));
+}
+
+TEST(BitSpan, GetI32_zeroDataLen)
+{
+    const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF};
+    ASSERT_EQ(0, nunavut::support::const_bitspan(data, 0).getI32(0U));
+}
+
+// +--------------------------------------------------------------------------+
+// | nunavutGetI64
+// +--------------------------------------------------------------------------+
+
+TEST(BitSpan, GetI64)
+{
+    const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI64(64U));
+}
+
+TEST(BitSpan, GetI64_tooSmall)
+{
+    const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    ASSERT_EQ(9223372036854775807, nunavut::support::const_bitspan(data, 1).getI64(64U));
+}
+
+TEST(BitSpan, GetI64_tooSmallAndNegative)
+{
+    const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI64(60U));
+}
+
+TEST(BitSpan, GetI64_zeroDataLen)
+{
+    const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    ASSERT_EQ(0, nunavut::support::const_bitspan(data, 0).getI64(0U));
+}

--- a/verification/cpp/suite/test_compiles.cpp
+++ b/verification/cpp/suite/test_compiles.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
+ * Authors: Scott Dixon <dixonsco@amazon.com>, Pavel Pletenev <cpp.create@gmail.com>
  * Sanity tests.
  */
 #include "gmock/gmock.h"

--- a/verification/cpp/suite/test_helpers.hpp
+++ b/verification/cpp/suite/test_helpers.hpp
@@ -9,18 +9,18 @@
 #include "gmock/gmock.h"
 #include "nunavut/support/serialization.hpp"
 
-#if __cplusplus > 201703L
-#include "magic_enum.hpp"
 testing::Message& operator<<(testing::Message& s, const nunavut::support::Error& e){
-    s << magic_enum::enum_name(e);
+    using namespace nunavut::support;
+    switch(e){
+    case Error::SERIALIZATION_INVALID_ARGUMENT: s << "SERIALIZATION_INVALID_ARGUMENT"; break;
+    case Error::SERIALIZATION_BUFFER_TOO_SMALL: s << "SERIALIZATION_BUFFER_TOO_SMALL"; break;
+    case Error::REPRESENTATION_BAD_ARRAY_LENGTH: s << "REPRESENTATION_BAD_ARRAY_LENGTH"; break;
+    case Error::REPRESENTATION_BAD_UNION_TAG: s << "REPRESENTATION_BAD_UNION_TAG"; break;
+    case Error::REPRESENTATION_BAD_DELIMITER_HEADER: s << "REPRESENTATION_BAD_DELIMITER_HEADER"; break;
+    }
     return s;
 }
-#else
-testing::Message& operator<<(testing::Message& s, const nunavut::support::Error& e){
-    s << static_cast<std::underlying_type_t<nunavut::support::Error>>(e);
-    return s;
-}
-#endif
+
 
 namespace nunavut{
 namespace testing{

--- a/verification/cpp/suite/test_helpers.hpp
+++ b/verification/cpp/suite/test_helpers.hpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022 UAVCAN Development Team.
+ * Authors: Pavel Pletenev <cpp.create@gmail.com>
+ * This software is distributed under the terms of the MIT License.
+ *
+ * Tests of serialization
+ */
+
+#include "gmock/gmock.h"
+#include "nunavut/support/serialization.hpp"
+
+#if __cplusplus > 201703L
+#include "magic_enum.hpp"
+testing::Message& operator<<(testing::Message& s, const nunavut::support::Error& e){
+    s << magic_enum::enum_name(e);
+    return s;
+}
+#else
+testing::Message& operator<<(testing::Message& s, const nunavut::support::Error& e){
+    s << static_cast<std::underlying_type_t<nunavut::support::Error>>(e);
+    return s;
+}
+#endif
+
+namespace nunavut{
+namespace testing{
+
+
+template<typename I>
+class Hex {
+    using ft = std::conditional_t<(sizeof(I)<=2), std::conditional_t<(std::is_signed<I>::value), int16_t, uint16_t>, I>;
+public:
+    explicit Hex(I n) : number_(n) {}
+    operator I() { return number_; }
+
+    friend std::ostream& operator<<(std::ostream& s, const Hex& h){
+        s << std::hex << static_cast<ft>(h.number_);
+        return s;
+    }
+    bool operator==(const Hex& other)const{
+        return number_ == other.number_;
+    }
+private:
+    I number_;
+};
+
+template<typename I>
+Hex<I> hex(I&& i){
+    return Hex<I>(std::forward<I>(i));
+}
+
+} // namespace testing
+} // namespace nunavut
+
+inline int8_t randI8(void)
+{
+    return static_cast<int8_t>(rand());
+}
+
+inline int16_t randI16(void)
+{
+    return static_cast<int16_t>((randI8() + 1) * randI8());
+}
+
+inline int32_t randI32(void)
+{
+    return static_cast<int32_t>((randI16() + 1L) * randI16());
+}
+
+inline int64_t randI64(void)
+{
+    return static_cast<int64_t>((randI32() + 1LL) * randI32());
+}
+
+inline uint8_t randU8(void)
+{
+    return static_cast<uint8_t>(rand());
+}
+
+inline uint16_t randU16(void)
+{
+    return static_cast<uint16_t>((randU8() + 1) * randU8());
+}
+
+inline uint32_t randU32(void)
+{
+    return static_cast<uint32_t>((randU16() + 1L) * randU16());
+}
+
+inline uint64_t randU64(void)
+{
+    return static_cast<uint64_t>((randU32() + 1LL) * randU32());
+}
+
+inline float randF16(void)
+{
+    return static_cast<float>(randI8());
+}
+
+inline float randF32(void)
+{
+    return static_cast<float>(randI64());
+}
+
+inline double randF64(void)
+{
+    return static_cast<double>(randI64());
+}

--- a/verification/cpp/suite/test_helpers.hpp
+++ b/verification/cpp/suite/test_helpers.hpp
@@ -106,3 +106,10 @@ inline double randF64(void)
 {
     return static_cast<double>(randI64());
 }
+
+::testing::AssertionResult CompareFloatsNear(float f1, float f2, float delta) {
+  if (std::abs(f1-f2) < delta)
+    return testing::AssertionSuccess();
+  else
+    return testing::AssertionFailure() << "Value " << f1 << " is not equal to " << f2 << " up to " << delta;
+}

--- a/verification/cpp/suite/test_serialization.cpp
+++ b/verification/cpp/suite/test_serialization.cpp
@@ -119,11 +119,8 @@ TEST(Serialization, StructReference)
     obj.unaligned_bitpacked_lt3.emplace_back(1);
     obj.unaligned_bitpacked_lt3.emplace_back(0);
     ASSERT_EQ(2U, obj.unaligned_bitpacked_lt3.size());              // 0b01, rest truncated
-    // obj.delimited_var_2[0].f16
-    // regulated_basics_DelimitedVariableSize_0_1_select_f16_(&obj.delimited_var_2[0]);
-    // obj.delimited_var_2[0].f16 = +1e9F;                 // truncated to infinity
-    // regulated_basics_DelimitedVariableSize_0_1_select_f64_(&obj.delimited_var_2[1]);
-    // obj.delimited_var_2[1].f64 = -1e40;                 // retained
+    obj.delimited_var_2[0].set_f16(+1e9F);    // truncated to infinity
+    obj.delimited_var_2[1].set_f16(-1e40);    // retained
     obj.aligned_bitpacked_le3.emplace_back(1);
     ASSERT_EQ(1U, obj.aligned_bitpacked_le3.size());                // only lsb is set, other truncated
 
@@ -250,9 +247,16 @@ TEST(Serialization, StructReference)
     ASSERT_EQ(0U, obj.unaligned_bitpacked_lt3.size());
 
     // ASSERT_EQ(0, obj.delimited_var_2[0]._tag_);
-    ASSERT_TRUE(CompareFloatsNear(0.f, obj.delimited_var_2[0].f16, 1e-9f));
-    // ASSERT_EQ(0, obj.delimited_var_2[1]._tag_);
-    ASSERT_TRUE(CompareFloatsNear(0.f, obj.delimited_var_2[1].f16, 1e-9f));
+    {
+        auto ptr_f16 = obj.delimited_var_2[0].get_f16_if();
+        ASSERT_NE(nullptr, ptr_f16);
+        ASSERT_TRUE(CompareFloatsNear(0.f, *ptr_f16, 1e-9f));
+    }
+    {
+        auto ptr_f16 = obj.delimited_var_2[1].get_f16_if();
+        ASSERT_NE(nullptr, ptr_f16);
+        ASSERT_TRUE(CompareFloatsNear(0.f, *ptr_f16, 1e-9f));
+    }
 
     ASSERT_EQ(0U, obj.aligned_bitpacked_le3.size());
 

--- a/verification/cpp/suite/test_serialization.cpp
+++ b/verification/cpp/suite/test_serialization.cpp
@@ -248,10 +248,12 @@ TEST(Serialization, StructReference)
     ASSERT_EQ(0, obj.aligned_bitpacked_3[1]);
     ASSERT_EQ(0, obj.aligned_bitpacked_3[2]);
     ASSERT_EQ(0U, obj.unaligned_bitpacked_lt3.size());
+
     // ASSERT_EQ(0, obj.delimited_var_2[0]._tag_);
-    ASSERT_NEAR(0, obj.delimited_var_2[0].f16, 1e-9);
+    ASSERT_TRUE(CompareFloatsNear(0.f, obj.delimited_var_2[0].f16, 1e-9f));
     // ASSERT_EQ(0, obj.delimited_var_2[1]._tag_);
-    ASSERT_NEAR(0, obj.delimited_var_2[1].f16, 1e-9);
+    ASSERT_TRUE(CompareFloatsNear(0.f, obj.delimited_var_2[1].f16, 1e-9f));
+
     ASSERT_EQ(0U, obj.aligned_bitpacked_le3.size());
 
     // // Deserialize the above reference representation and compare the result against the original object.
@@ -263,7 +265,7 @@ TEST(Serialization, StructReference)
     // ASSERT_EQ(-512, obj.i10_4[1]);                              // saturated
     // ASSERT_EQ(+0x55, obj.i10_4[2]);
     // ASSERT_EQ(-0xAA, obj.i10_4[3]);
-    // ASSERT_NEAR(-65504.0, obj.f16_le2.elements[0], 1e-3);
+    // ASSERT_TRUE(CompareFloatsNear(-65504.0f, obj.f16_le2.elements[0], 1e-3f));
     // TEST_ASSERT_FLOAT_IS_INF(obj.f16_le2.elements[1]);
     // ASSERT_EQ(2, obj.f16_le2.count);
     // ASSERT_EQ(5, obj.unaligned_bitpacked_3_bitpacked_[0]);      // unused MSB are zero-padded
@@ -300,7 +302,7 @@ TEST(Serialization, StructReference)
     // ASSERT_EQ(-512, obj.i10_4[1]);                              // saturated
     // ASSERT_EQ(+0x55, obj.i10_4[2]);
     // ASSERT_EQ(-0xAA, obj.i10_4[3]);
-    // ASSERT_NEAR(-65504.0, obj.f16_le2.elements[0], 1e-3);
+    // ASSERT_TRUE(CompareFloatsNear(-65504.0, obj.f16_le2.elements[0], 1e-3));
     // TEST_ASSERT_FLOAT_IS_INF(obj.f16_le2.elements[1]);
     // ASSERT_EQ(2, obj.f16_le2.count);
     // ASSERT_EQ(5, obj.unaligned_bitpacked_3_bitpacked_[0]);      // unused MSB are zero-padded
@@ -320,9 +322,9 @@ TEST(Serialization, StructReference)
     // ASSERT_EQ(0, obj.aligned_bitpacked_3_bitpacked_[0]);        //      ZEROS
     // ASSERT_EQ(0, obj.unaligned_bitpacked_lt3.count);            //          ALL
     // ASSERT_EQ(0, obj.delimited_var_2[0]._tag_);                 //              THE
-    // ASSERT_NEAR(0, obj.delimited_var_2[0].f16, 1e-9);      //                  WAY
+    // ASSERT_TRUE(CompareFloatsNear(0, obj.delimited_var_2[0].f16, 1e-9);      //                  WA)Y
     // ASSERT_EQ(0, obj.delimited_var_2[1]._tag_);                 //                      DOWN
-    // ASSERT_NEAR(0, obj.delimited_var_2[1].f16, 1e-9);
+    // ASSERT_TRUE(CompareFloatsNear(0, obj.delimited_var_2[1].f16, 1e-9));
     // ASSERT_EQ(0, obj.aligned_bitpacked_le3.count);
 }
 

--- a/verification/cpp/suite/test_serialization.cpp
+++ b/verification/cpp/suite/test_serialization.cpp
@@ -82,7 +82,6 @@ TEST(Serialization, BasicSerialize) {
 ///     print('\n'.join(f'0x{x:02X}U,' for x in sr))
 TEST(Serialization, StructReference)
 {
-    return;
     regulated::basics::Struct__0_1 obj{};
 
     // Initialize a reference object, serialize, and compare against the reference serialized representation.
@@ -120,80 +119,79 @@ TEST(Serialization, StructReference)
     obj.unaligned_bitpacked_lt3.emplace_back(0);
     ASSERT_EQ(2U, obj.unaligned_bitpacked_lt3.size());              // 0b01, rest truncated
     obj.delimited_var_2[0].set_f16(+1e9F);    // truncated to infinity
-    obj.delimited_var_2[1].set_f16(-1e40);    // retained
+    obj.delimited_var_2[1].set_f64(-1e40);    // retained
     obj.aligned_bitpacked_le3.emplace_back(1);
     ASSERT_EQ(1U, obj.aligned_bitpacked_le3.size());                // only lsb is set, other truncated
 
     const uint8_t reference[] = {
-        0xFEU,  // void1, true, 6 lsb of int10 = 511
-        0x07U,  // 4 msb of int10 = 511, 4 lsb of -512 = 0b_10_0000_0000
-        0x60U,  // 6 msb of -512 (0x60 = 0b_0110_0000), 2 lsb of 0x0055 = 0b0001010101
-        0x15U,  // 8 msb of 0b_00_0101_0101,                       0x15 = 0b00010101
-        0x56U,  // ALIGNED; -0x00AA in two's complement is 0x356 = 0b_11_01010110
-        0x0BU,  // 2 msb of the above (0b11) followed by 8 bit of length prefix (2) of float16[<=2] f16_le2
-        0xFCU,  // 2 msb of the length prefix followed by 6 lsb of (float16.min = 0xfbff = 0b_11111011_11111111)
-        0xEFU,  // 0b_xx_111011_11xxxxxx (continuation of the float16)
-        0x03U,  // 2 msb of the above (0b11) and the next float16 = +inf, represented 0x7C00 = 0b_01111100_00000000
-        0xF0U,  // 0b_xx111100_00xxxxxx (continuation of the infinity)
-        0x15U,  // 2 msb of the above (0b01) followed by bool[3] unaligned_bitpacked_3 = [1, 0, 1], then PADDING
-        0x02U,  // ALIGNED; empty struct not manifested, here we have length = 2 of uint8[<3] bytes_lt3
-        0x6FU,  // bytes_lt3[0] = 111
-        0xDEU,  // bytes_lt3[1] = 222
-        0x89U,  // bytes_3[0] = -0x77 (two's complement)
-        0xEFU,  // bytes_3[1] = -0x11 (two's complement)
-        0x77U,  // bytes_3[2] = +0x77
-        0x03U,  // length = 3 of truncated uint2[<=4] u2_le4
-        0x36U,  // 0b_00_11_01_10: u2_le4[0] = 0b10, u2_le4[1] = 0b01, u2_le4[2] = 0b11, then dynamic padding
-        0x01U,  // ALIGNED; length = 1 of DelimitedFixedSize.0.1[<=2] delimited_fix_le2
-        0x00U,  // Constant DH of DelimitedFixedSize.0.1
-        0x00U,  // ditto
-        0x00U,  // ditto
-        0x00U,  // ditto
-        0x34U,  // uint16[2] u16_2; first element = 0x1234
-        0x12U,  // continuation
-        0x78U,  // second element = 0x5678
-        0x56U,  // continuation
-        0x11U,  // bool[3] aligned_bitpacked_3 = [1, 0, 0]; then 5 lsb of length = 2 of bool[<3] unaligned_bitpacked_lt3
-        0x08U,  // 3 msb of length = 2 (i.e., zeros), then values [1, 0], then 1 bit of padding before composite
-        0x03U,  // DH = 3 of the first element of DelimitedVariableSize.0.1[2] delimited_var_2
-        0x00U,  // ditto
-        0x00U,  // ditto
-        0x00U,  // ditto
-        0x00U,  // union tag = 0, f16 selected
-        0x00U,  // f16 truncated to positive infinity; see representation above
-        0x7CU,  // ditto
-        0x09U,  // DH = (8 + 1) of the second element of DelimitedVariableSize.0.1[2] delimited_var_2
-        0x00U,  // ditto
-        0x00U,  // ditto
-        0x00U,  // ditto
-        0x02U,  // union tag = 2, f64 selected (notice that union tags are always aligned by design)
-        0xA5U,  // float64 = -1e40 is 0xc83d6329f1c35ca5, this is the LSB
-        0x5CU,  // ditto
-        0xC3U,  // ditto
-        0xF1U,  // ditto
-        0x29U,  // ditto
-        0x63U,  // ditto
-        0x3DU,  // ditto
-        0xC8U,  // ditto
-        0x01U,  // length = 1 of bool[<=3] aligned_bitpacked_le3
-        0x01U,  // the one single bit of the above, then 7 bits of dynamic padding to byte
-        // END OF SERIALIZED REPRESENTATION
-        0x55U,  // canary  1
-        0x55U,  // canary  2
-        0x55U,  // canary  3
-        0x55U,  // canary  4
-        0x55U,  // canary  5
-        0x55U,  // canary  6
-        0x55U,  // canary  7
-        0x55U,  // canary  8
-        0x55U,  // canary  9
-        0x55U,  // canary 10
-        0x55U,  // canary 11
-        0x55U,  // canary 12
-        0x55U,  // canary 13
-        0x55U,  // canary 14
-        0x55U,  // canary 15
-        0x55U,  // canary 16
+        0xFEU,  // byte 0: void1, true, 6 lsb of int10 = 511
+        0x07U,  // byte 1: 4 msb of int10 = 511, 4 lsb of -512 = 0b_10_0000_0000
+        0x60U,  // byte 2: 6 msb of -512 (0x60 = 0b_0110_0000), 2 lsb of 0x0055 = 0b0001010101
+        0x15U,  // byte 3: 8 msb of 0b_00_0101_0101,                       0x15 = 0b00010101
+        0x56U,  // byte 4: ALIGNED; -0x00AA in two's complement is 0x356 = 0b_11_01010110
+        0x0BU,  // byte 5: 2 msb of the above (0b11) followed by 8 bit of length prefix (2) of float16[<=2] f16_le2
+        0xFCU,  // byte 6: 2 msb of the length prefix followed by 6 lsb of (float16.min = 0xfbff = 0b_11111011_11111111)
+        0xEFU,  // byte 7: 0b_xx_111011_11xxxxxx (continuation of the float16)
+        0x03U,  // byte 8: 2 msb of the above (0b11) and the next float16 = +inf, represented 0x7C00 = 0b_01111100_00000000
+        0xF0U,  // byte 9: 0b_xx111100_00xxxxxx (continuation of the infinity)
+        0x15U,  // byte 10: 2 msb of the above (0b01) followed by bool[3] unaligned_bitpacked_3 = [1, 0, 1], then PADDING
+        0x02U,  // byte 11: ALIGNED; empty struct not manifested, here we have length = 2 of uint8[<3] bytes_lt3
+        0x6FU,  // byte 12: bytes_lt3[0] = 111
+        0xDEU,  // byte 13: bytes_lt3[1] = 222
+        0x89U,  // byte 14: bytes_3[0] = -0x77 (two's complement)
+        0xEFU,  // byte 15: bytes_3[1] = -0x11 (two's complement)
+        0x77U,  // byte 16: bytes_3[2] = +0x77
+        0x03U,  // byte 17: length = 3 of truncated uint2[<=4] u2_le4
+        0x36U,  // byte 18: 0b_00_11_01_10: u2_le4[0] = 0b10, u2_le4[1] = 0b01, u2_le4[2] = 0b11, then dynamic padding
+        0x01U,  // byte 19: ALIGNED; length = 1 of DelimitedFixedSize.0.1[<=2] delimited_fix_le2
+        0x00U,  // byte 20: Constant DH of DelimitedFixedSize.0.1
+        0x00U,  // byte 21: ditto
+        0x00U,  // byte 22: ditto
+        0x00U,  // byte 23: ditto
+        0x34U,  // byte 24: uint16[2] u16_2; first element = 0x1234
+        0x12U,  // byte 25: continuation
+        0x78U,  // byte 26: second element = 0x5678
+        0x56U,  // byte 27: continuation
+        0x11U,  // byte 28: bool[3] aligned_bitpacked_3 = [1, 0, 0]; then 5 lsb of length = 2 of bool[<3] unaligned_bitpacked_lt3
+        0x08U,  // byte 29: 3 msb of length = 2 (i.e., zeros), then values [1, 0], then 1 bit of padding before composite
+        0x03U,  // byte 30: DH = 3 of the first element of DelimitedVariableSize.0.1[2] delimited_var_2
+        0x00U,  // byte 31: ditto
+        0x00U,  // byte 32: ditto
+        0x00U,  // byte 33: ditto
+        0x00U,  // byte 34: union tag = 0, f16 selected
+        0x00U,  // byte 35: f16 truncated to positive infinity; see representation above
+        0x7CU,  // byte 36: ditto
+        0x09U,  // byte 37: DH = (8 + 1) of the second element of DelimitedVariableSize.0.1[2] delimited_var_2
+        0x00U,  // byte 38: ditto
+        0x00U,  // byte 39: ditto
+        0x00U,  // byte 40: ditto
+        0x02U,  // byte 41: union tag = 2, f64 selected (notice that union tags are always aligned by design)
+        0xA5U,  // byte 42: float64 = -1e40 is 0xc83d6329f1c35ca5, this is the LSB
+        0x5CU,  // byte 43: ditto
+        0xC3U,  // byte 44: ditto
+        0xF1U,  // byte 45: ditto
+        0x29U,  // byte 46: ditto
+        0x63U,  // byte 47: ditto
+        0x3DU,  // byte 48: ditto
+        0xC8U,  // byte 49: ditto
+        0x01U,  // byte 50: length = 1 of bool[<=3] aligned_bitpacked_le3
+        0x01U,  // byte 51: the one single bit of the above, then 7 bits of dynamic padding to byte// byte 51: END OF SERIALIZED REPRESENTATION
+        0x55U,  // byte 52: canary  1
+        0x55U,  // byte 53: canary  2
+        0x55U,  // byte 54: canary  3
+        0x55U,  // byte 55: canary  4
+        0x55U,  // byte 56: canary  5
+        0x55U,  // byte 57: canary  6
+        0x55U,  // byte 58: canary  7
+        0x55U,  // byte 59: canary  8
+        0x55U,  // byte 60: canary  9
+        0x55U,  // byte 61: canary 10
+        0x55U,  // byte 62: canary 11
+        0x55U,  // byte 63: canary 12
+        0x55U,  // byte 64: canary 13
+        0x55U,  // byte 65: canary 14
+        0x55U,  // byte 66: canary 15
+        0x55U,  // byte 67: canary 16
     };
 
     uint8_t buf[sizeof(reference)];
@@ -202,33 +200,33 @@ TEST(Serialization, StructReference)
     auto result = obj.serialize({{buf, sizeof(buf)}});
     ASSERT_TRUE(result) << "Error is " << static_cast<int>(result.error());
 
-    ASSERT_EQ(sizeof(reference) - 16U, result.value());
+    EXPECT_EQ(sizeof(reference) - 16U, result.value());
 
     for(size_t i=0; i< sizeof(reference); i++){
         ASSERT_EQ(reference[i], buf[i]) << "Failed at " << i;
     }
 
-
     // Check union manipulation functions.
-    // TEST_ASSERT_TRUE(regulated_basics_DelimitedVariableSize_0_1_is_f16_(&obj.delimited_var_2[0]));
-    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f32_(&obj.delimited_var_2[0]));
-    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f64_(&obj.delimited_var_2[0]));
-    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f64_(NULL));
-    // regulated_basics_DelimitedVariableSize_0_1_select_f32_(NULL);        // No action; same state retained.
-    // TEST_ASSERT_TRUE(regulated_basics_DelimitedVariableSize_0_1_is_f16_(&obj.delimited_var_2[0]));
-    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f32_(&obj.delimited_var_2[0]));
-    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f64_(&obj.delimited_var_2[0]));
-    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f64_(NULL));
+    ASSERT_TRUE(obj.delimited_var_2[0].is_f16());
+    ASSERT_FALSE(obj.delimited_var_2[0].is_f32());
+    ASSERT_FALSE(obj.delimited_var_2[0].is_f64());
+    obj.delimited_var_2[0].set_f32();
+    ASSERT_FALSE(obj.delimited_var_2[0].is_f16());
+    ASSERT_TRUE(obj.delimited_var_2[0].is_f32());
+    ASSERT_FALSE(obj.delimited_var_2[0].is_f64());
+    obj.delimited_var_2[0].set_f64();
+    ASSERT_FALSE(obj.delimited_var_2[0].is_f16());
+    ASSERT_FALSE(obj.delimited_var_2[0].is_f32());
+    ASSERT_TRUE(obj.delimited_var_2[0].is_f64());
 
     // Test default initialization.
-    // (void) memset(&obj, 0x55, sizeof(obj));             // Fill using a non-zero pattern.
     obj.regulated::basics::Struct__0_1::~Struct__0_1();
     new (&obj)regulated::basics::Struct__0_1();
     ASSERT_EQ(false, obj.boolean);
-    // ASSERT_EQ(0, obj.i10_4[0]);
-    // ASSERT_EQ(0, obj.i10_4[1]);
-    // ASSERT_EQ(0, obj.i10_4[2]);
-    // ASSERT_EQ(0, obj.i10_4[3]);
+    ASSERT_EQ(0, obj.i10_4[0]);
+    ASSERT_EQ(0, obj.i10_4[1]);
+    ASSERT_EQ(0, obj.i10_4[2]);
+    ASSERT_EQ(0, obj.i10_4[3]);
     ASSERT_EQ(0U, obj.f16_le2.size());
     ASSERT_EQ(0, obj.unaligned_bitpacked_3[0]);
     ASSERT_EQ(0, obj.unaligned_bitpacked_3[1]);
@@ -261,8 +259,10 @@ TEST(Serialization, StructReference)
     ASSERT_EQ(0U, obj.aligned_bitpacked_le3.size());
 
     // // Deserialize the above reference representation and compare the result against the original object.
+    result = obj.deserialize({{reference}, 0U});
+    ASSERT_TRUE(result) << "Error was " << result.error();
     // ASSERT_EQ(0, regulated_basics_Struct__0_1_deserialize_(&obj, &reference[0], &size));
-    // ASSERT_EQ(sizeof(reference) - 16U, size);   // 16 trailing bytes implicitly truncated away
+    ASSERT_EQ(sizeof(reference) - 16U, result.value());   // 16 trailing bytes implicitly truncated away
 
     // ASSERT_EQ(true, obj.boolean);
     // ASSERT_EQ(+511, obj.i10_4[0]);                              // saturated

--- a/verification/cpp/suite/test_serialization.cpp
+++ b/verification/cpp/suite/test_serialization.cpp
@@ -1,0 +1,407 @@
+/*
+ * Copyright (c) 2022 UAVCAN Development Team.
+ * Authors: Pavel Pletenev <cpp.create@gmail.com>
+ * This software is distributed under the terms of the MIT License.
+ *
+ * Tests of serialization
+ */
+
+#include "test_helpers.hpp"
+#include "uavcan/time/TimeSystem_0_1.hpp"
+#include "regulated/basics/Struct__0_1.hpp"
+#include "regulated/basics/Primitive_0_1.hpp"
+
+
+
+TEST(Serialization, BasicSerialize) {
+    uavcan::time::TimeSystem_0_1 a;
+    uint8_t buffer[8]{};
+    {
+        a.value = 1;
+        std::fill(std::begin(buffer), std::end(buffer), 0xAA);
+        const auto result = a.serialize({{buffer}});
+        ASSERT_TRUE(result);
+        ASSERT_EQ(1U, *result);
+        ASSERT_EQ(1U, buffer[0]);
+        ASSERT_EQ(0xAA, buffer[1]);
+    }
+    {
+        a.value = 0xFF;
+        std::fill(std::begin(buffer), std::end(buffer), 0xAA);
+        const auto result = a.serialize({{buffer}});
+        ASSERT_TRUE(result);
+        ASSERT_EQ(1U, *result);
+        ASSERT_EQ(0x0FU, buffer[0]);
+        ASSERT_EQ(0xAAU, buffer[1]);
+    }
+}
+
+/// This was copied from C counterpart and modified for C++
+/// The reference array has been pedantically validated manually bit by bit (it did really took authors of
+/// C tests about three hours).
+/// The following Python script has been used to cross-check against PyUAVCAN, which has been cross-checked against
+/// earlier v0 implementations beforehand:
+///
+///     import sys, pathlib, importlib, pyuavcan
+///     sys.path.append(str(pathlib.Path.cwd()))
+///     target, lookup = sys.argv[1], sys.argv[2:]
+///     for lk in lookup:
+///         pyuavcan.dsdl.generate_package(lk, lookup)
+///     pyuavcan.dsdl.generate_package(target, lookup)
+///     from regulated.basics import Struct__0_1, DelimitedFixedSize_0_1, DelimitedVariableSize_0_1, Union_0_1
+///     s = Struct__0_1()
+///     s.boolean = True
+///     s.i10_4[0] = +0x5555                              # saturates to +511
+///     s.i10_4[1] = -0x6666                              # saturates to -512
+///     s.i10_4[2] = +0x0055                              # original value retained
+///     s.i10_4[3] = -0x00AA                              # original value retained
+///     s.f16_le2 = [
+///         -65504.0,
+///         +float('inf'),                                # negative infinity retained
+///     ]
+///     s.unaligned_bitpacked_3 = [1, 0, 1]
+///     s.bytes_lt3 = [111, 222]
+///     s.bytes_3[0] = -0x77
+///     s.bytes_3[1] = -0x11
+///     s.bytes_3[2] = +0x77
+///     s.u2_le4 = [
+///         0x02,                                         # retained
+///         0x11,                                         # truncated => 1
+///         0xFF,                                         # truncated => 3
+///     ]
+///     s.delimited_fix_le2 = [DelimitedFixedSize_0_1()]
+///     s.u16_2[0] = 0x1234
+///     s.u16_2[1] = 0x5678
+///     s.aligned_bitpacked_3 = [1, 0, 0]
+///     s.unaligned_bitpacked_lt3 = [1, 0]                # 0b01
+///     s.delimited_var_2[0].f16 = +float('inf')
+///     s.delimited_var_2[1].f64 = -1e40                  # retained
+///     s.aligned_bitpacked_le3 = [1]
+///     sr = b''.join(pyuavcan.dsdl.serialize(s))
+///     print(len(sr), 'bytes')
+///     print('\n'.join(f'0x{x:02X}U,' for x in sr))
+TEST(Serialization, StructReference)
+{
+    return;
+    regulated::basics::Struct__0_1 obj{};
+
+    // Initialize a reference object, serialize, and compare against the reference serialized representation.
+    obj.boolean = true;
+    obj.i10_4[0] = +0x5555;                             // saturates to +511
+    obj.i10_4[1] = -0x6666;                             // saturates to -512
+    obj.i10_4[2] = +0x0055;                             // original value retained
+    obj.i10_4[3] = -0x00AA;                             // original value retained
+    obj.f16_le2.emplace_back(-1e9F);                    // saturated to -65504
+    obj.f16_le2.emplace_back(+INFINITY);                // infinity retained
+    ASSERT_EQ(2U, obj.f16_le2.size());
+    //obj.unaligned_bitpacked_3[0] = 0xF5;     // 0b101, rest truncated away and ignored TODO:Fix
+    obj.unaligned_bitpacked_3[0] = 1;
+    obj.unaligned_bitpacked_3[1] = 0;
+    obj.unaligned_bitpacked_3[2] = 1;
+    //obj.sealed = 123;                           // ignored
+    obj.bytes_lt3.emplace_back(111);
+    obj.bytes_lt3.emplace_back(222);
+    ASSERT_EQ(2U, obj.bytes_lt3.size());
+    obj.bytes_3[0] = -0x77;
+    obj.bytes_3[1] = -0x11;
+    obj.bytes_3[2] = +0x77;
+    obj.u2_le4.emplace_back(0x02);                      // retained
+    obj.u2_le4.emplace_back(0x11);                      // truncated => 1
+    obj.u2_le4.emplace_back(0xFF);                      // truncated => 3
+    //obj.u2_le4.emplace_back(0xFF);                      // ignored because the length is 3
+    ASSERT_EQ(3U, obj.u2_le4.size());
+    obj.delimited_fix_le2.emplace_back();    // ignored
+    ASSERT_EQ(1U, obj.delimited_fix_le2.size());
+    obj.u16_2[0] = 0x1234;
+    obj.u16_2[1] = 0x5678;
+    obj.aligned_bitpacked_3[0] = 0xF1U;
+    // obj.unaligned_bitpacked_lt3.bitpacked[0] = 0xF1U;
+    obj.unaligned_bitpacked_lt3.emplace_back(1);
+    obj.unaligned_bitpacked_lt3.emplace_back(0);
+    ASSERT_EQ(2U, obj.unaligned_bitpacked_lt3.size());              // 0b01, rest truncated
+    // obj.delimited_var_2[0].f16
+    // regulated_basics_DelimitedVariableSize_0_1_select_f16_(&obj.delimited_var_2[0]);
+    // obj.delimited_var_2[0].f16 = +1e9F;                 // truncated to infinity
+    // regulated_basics_DelimitedVariableSize_0_1_select_f64_(&obj.delimited_var_2[1]);
+    // obj.delimited_var_2[1].f64 = -1e40;                 // retained
+    obj.aligned_bitpacked_le3.emplace_back(1);
+    ASSERT_EQ(1U, obj.aligned_bitpacked_le3.size());                // only lsb is set, other truncated
+
+    const uint8_t reference[] = {
+        0xFEU,  // void1, true, 6 lsb of int10 = 511
+        0x07U,  // 4 msb of int10 = 511, 4 lsb of -512 = 0b_10_0000_0000
+        0x60U,  // 6 msb of -512 (0x60 = 0b_0110_0000), 2 lsb of 0x0055 = 0b0001010101
+        0x15U,  // 8 msb of 0b_00_0101_0101,                       0x15 = 0b00010101
+        0x56U,  // ALIGNED; -0x00AA in two's complement is 0x356 = 0b_11_01010110
+        0x0BU,  // 2 msb of the above (0b11) followed by 8 bit of length prefix (2) of float16[<=2] f16_le2
+        0xFCU,  // 2 msb of the length prefix followed by 6 lsb of (float16.min = 0xfbff = 0b_11111011_11111111)
+        0xEFU,  // 0b_xx_111011_11xxxxxx (continuation of the float16)
+        0x03U,  // 2 msb of the above (0b11) and the next float16 = +inf, represented 0x7C00 = 0b_01111100_00000000
+        0xF0U,  // 0b_xx111100_00xxxxxx (continuation of the infinity)
+        0x15U,  // 2 msb of the above (0b01) followed by bool[3] unaligned_bitpacked_3 = [1, 0, 1], then PADDING
+        0x02U,  // ALIGNED; empty struct not manifested, here we have length = 2 of uint8[<3] bytes_lt3
+        0x6FU,  // bytes_lt3[0] = 111
+        0xDEU,  // bytes_lt3[1] = 222
+        0x89U,  // bytes_3[0] = -0x77 (two's complement)
+        0xEFU,  // bytes_3[1] = -0x11 (two's complement)
+        0x77U,  // bytes_3[2] = +0x77
+        0x03U,  // length = 3 of truncated uint2[<=4] u2_le4
+        0x36U,  // 0b_00_11_01_10: u2_le4[0] = 0b10, u2_le4[1] = 0b01, u2_le4[2] = 0b11, then dynamic padding
+        0x01U,  // ALIGNED; length = 1 of DelimitedFixedSize.0.1[<=2] delimited_fix_le2
+        0x00U,  // Constant DH of DelimitedFixedSize.0.1
+        0x00U,  // ditto
+        0x00U,  // ditto
+        0x00U,  // ditto
+        0x34U,  // uint16[2] u16_2; first element = 0x1234
+        0x12U,  // continuation
+        0x78U,  // second element = 0x5678
+        0x56U,  // continuation
+        0x11U,  // bool[3] aligned_bitpacked_3 = [1, 0, 0]; then 5 lsb of length = 2 of bool[<3] unaligned_bitpacked_lt3
+        0x08U,  // 3 msb of length = 2 (i.e., zeros), then values [1, 0], then 1 bit of padding before composite
+        0x03U,  // DH = 3 of the first element of DelimitedVariableSize.0.1[2] delimited_var_2
+        0x00U,  // ditto
+        0x00U,  // ditto
+        0x00U,  // ditto
+        0x00U,  // union tag = 0, f16 selected
+        0x00U,  // f16 truncated to positive infinity; see representation above
+        0x7CU,  // ditto
+        0x09U,  // DH = (8 + 1) of the second element of DelimitedVariableSize.0.1[2] delimited_var_2
+        0x00U,  // ditto
+        0x00U,  // ditto
+        0x00U,  // ditto
+        0x02U,  // union tag = 2, f64 selected (notice that union tags are always aligned by design)
+        0xA5U,  // float64 = -1e40 is 0xc83d6329f1c35ca5, this is the LSB
+        0x5CU,  // ditto
+        0xC3U,  // ditto
+        0xF1U,  // ditto
+        0x29U,  // ditto
+        0x63U,  // ditto
+        0x3DU,  // ditto
+        0xC8U,  // ditto
+        0x01U,  // length = 1 of bool[<=3] aligned_bitpacked_le3
+        0x01U,  // the one single bit of the above, then 7 bits of dynamic padding to byte
+        // END OF SERIALIZED REPRESENTATION
+        0x55U,  // canary  1
+        0x55U,  // canary  2
+        0x55U,  // canary  3
+        0x55U,  // canary  4
+        0x55U,  // canary  5
+        0x55U,  // canary  6
+        0x55U,  // canary  7
+        0x55U,  // canary  8
+        0x55U,  // canary  9
+        0x55U,  // canary 10
+        0x55U,  // canary 11
+        0x55U,  // canary 12
+        0x55U,  // canary 13
+        0x55U,  // canary 14
+        0x55U,  // canary 15
+        0x55U,  // canary 16
+    };
+
+    uint8_t buf[sizeof(reference)];
+    (void) memset(&buf[0], 0x55U, sizeof(buf));  // fill out canaries
+
+    auto result = obj.serialize({{buf, sizeof(buf)}});
+    ASSERT_TRUE(result) << "Error is " << static_cast<int>(result.error());
+
+    ASSERT_EQ(sizeof(reference) - 16U, result.value());
+
+    for(size_t i=0; i< sizeof(reference); i++){
+        ASSERT_EQ(reference[i], buf[i]) << "Failed at " << i;
+    }
+
+
+    // Check union manipulation functions.
+    // TEST_ASSERT_TRUE(regulated_basics_DelimitedVariableSize_0_1_is_f16_(&obj.delimited_var_2[0]));
+    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f32_(&obj.delimited_var_2[0]));
+    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f64_(&obj.delimited_var_2[0]));
+    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f64_(NULL));
+    // regulated_basics_DelimitedVariableSize_0_1_select_f32_(NULL);        // No action; same state retained.
+    // TEST_ASSERT_TRUE(regulated_basics_DelimitedVariableSize_0_1_is_f16_(&obj.delimited_var_2[0]));
+    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f32_(&obj.delimited_var_2[0]));
+    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f64_(&obj.delimited_var_2[0]));
+    // TEST_ASSERT_FALSE(regulated_basics_DelimitedVariableSize_0_1_is_f64_(NULL));
+
+    // Test default initialization.
+    // (void) memset(&obj, 0x55, sizeof(obj));             // Fill using a non-zero pattern.
+    obj.regulated::basics::Struct__0_1::~Struct__0_1();
+    new (&obj)regulated::basics::Struct__0_1();
+    ASSERT_EQ(false, obj.boolean);
+    // ASSERT_EQ(0, obj.i10_4[0]);
+    // ASSERT_EQ(0, obj.i10_4[1]);
+    // ASSERT_EQ(0, obj.i10_4[2]);
+    // ASSERT_EQ(0, obj.i10_4[3]);
+    ASSERT_EQ(0U, obj.f16_le2.size());
+    ASSERT_EQ(0, obj.unaligned_bitpacked_3[0]);
+    ASSERT_EQ(0, obj.unaligned_bitpacked_3[1]);
+    ASSERT_EQ(0, obj.unaligned_bitpacked_3[2]);
+    ASSERT_EQ(0U, obj.bytes_lt3.size());
+    ASSERT_EQ(0, obj.bytes_3[0]);
+    ASSERT_EQ(0, obj.bytes_3[1]);
+    ASSERT_EQ(0, obj.bytes_3[2]);
+    ASSERT_EQ(0U, obj.u2_le4.size());
+    ASSERT_EQ(0U, obj.delimited_fix_le2.size());
+    ASSERT_EQ(0, obj.u16_2[0]);
+    ASSERT_EQ(0, obj.u16_2[1]);
+    ASSERT_EQ(0, obj.aligned_bitpacked_3[0]);
+    ASSERT_EQ(0, obj.aligned_bitpacked_3[1]);
+    ASSERT_EQ(0, obj.aligned_bitpacked_3[2]);
+    ASSERT_EQ(0U, obj.unaligned_bitpacked_lt3.size());
+    // ASSERT_EQ(0, obj.delimited_var_2[0]._tag_);
+    ASSERT_NEAR(0, obj.delimited_var_2[0].f16, 1e-9);
+    // ASSERT_EQ(0, obj.delimited_var_2[1]._tag_);
+    ASSERT_NEAR(0, obj.delimited_var_2[1].f16, 1e-9);
+    ASSERT_EQ(0U, obj.aligned_bitpacked_le3.size());
+
+    // // Deserialize the above reference representation and compare the result against the original object.
+    // ASSERT_EQ(0, regulated_basics_Struct__0_1_deserialize_(&obj, &reference[0], &size));
+    // ASSERT_EQ(sizeof(reference) - 16U, size);   // 16 trailing bytes implicitly truncated away
+
+    // ASSERT_EQ(true, obj.boolean);
+    // ASSERT_EQ(+511, obj.i10_4[0]);                              // saturated
+    // ASSERT_EQ(-512, obj.i10_4[1]);                              // saturated
+    // ASSERT_EQ(+0x55, obj.i10_4[2]);
+    // ASSERT_EQ(-0xAA, obj.i10_4[3]);
+    // ASSERT_NEAR(-65504.0, obj.f16_le2.elements[0], 1e-3);
+    // TEST_ASSERT_FLOAT_IS_INF(obj.f16_le2.elements[1]);
+    // ASSERT_EQ(2, obj.f16_le2.count);
+    // ASSERT_EQ(5, obj.unaligned_bitpacked_3_bitpacked_[0]);      // unused MSB are zero-padded
+    // ASSERT_EQ(111, obj.bytes_lt3.elements[0]);
+    // ASSERT_EQ(222, obj.bytes_lt3.elements[1]);
+    // ASSERT_EQ(2, obj.bytes_lt3.count);
+    // ASSERT_EQ(-0x77, obj.bytes_3[0]);
+    // ASSERT_EQ(-0x11, obj.bytes_3[1]);
+    // ASSERT_EQ(+0x77, obj.bytes_3[2]);
+    // ASSERT_EQ(2, obj.u2_le4.elements[0]);
+    // ASSERT_EQ(1, obj.u2_le4.elements[1]);
+    // ASSERT_EQ(3, obj.u2_le4.elements[2]);
+    // ASSERT_EQ(3, obj.u2_le4.count);
+    // ASSERT_EQ(1, obj.delimited_fix_le2.count);
+    // ASSERT_EQ(0x1234, obj.u16_2[0]);
+    // ASSERT_EQ(0x5678, obj.u16_2[1]);
+    // ASSERT_EQ(1, obj.aligned_bitpacked_3_bitpacked_[0]);        // unused MSB are zero-padded
+    // ASSERT_EQ(1, obj.unaligned_bitpacked_lt3.bitpacked[0]);     // unused MSB are zero-padded
+    // ASSERT_EQ(2, obj.unaligned_bitpacked_lt3.count);
+    // ASSERT_EQ(0, obj.delimited_var_2[0]._tag_);
+    // TEST_ASSERT_FLOAT_IS_INF(obj.delimited_var_2[0].f16);
+    // ASSERT_EQ(2, obj.delimited_var_2[1]._tag_);
+    // TEST_ASSERT_DOUBLE_WITHIN(0.5, -1e+40, obj.delimited_var_2[1].f64);
+    // ASSERT_EQ(1, obj.aligned_bitpacked_le3.bitpacked[0]);       // unused MSB are zero-padded
+    // ASSERT_EQ(1, obj.aligned_bitpacked_le3.count);
+
+    // // Repeat the above, but apply implicit zero extension somewhere in the middle.
+    // size = 25U;
+    // ASSERT_EQ(0, regulated_basics_Struct__0_1_deserialize_(&obj, &reference[0], &size));
+    // ASSERT_EQ(25, size);   // the returned size shall not exceed the buffer size
+
+    // ASSERT_EQ(true, obj.boolean);
+    // ASSERT_EQ(+511, obj.i10_4[0]);                              // saturated
+    // ASSERT_EQ(-512, obj.i10_4[1]);                              // saturated
+    // ASSERT_EQ(+0x55, obj.i10_4[2]);
+    // ASSERT_EQ(-0xAA, obj.i10_4[3]);
+    // ASSERT_NEAR(-65504.0, obj.f16_le2.elements[0], 1e-3);
+    // TEST_ASSERT_FLOAT_IS_INF(obj.f16_le2.elements[1]);
+    // ASSERT_EQ(2, obj.f16_le2.count);
+    // ASSERT_EQ(5, obj.unaligned_bitpacked_3_bitpacked_[0]);      // unused MSB are zero-padded
+    // ASSERT_EQ(111, obj.bytes_lt3.elements[0]);
+    // ASSERT_EQ(222, obj.bytes_lt3.elements[1]);
+    // ASSERT_EQ(2, obj.bytes_lt3.count);
+    // ASSERT_EQ(-0x77, obj.bytes_3[0]);
+    // ASSERT_EQ(-0x11, obj.bytes_3[1]);
+    // ASSERT_EQ(+0x77, obj.bytes_3[2]);
+    // ASSERT_EQ(2, obj.u2_le4.elements[0]);
+    // ASSERT_EQ(1, obj.u2_le4.elements[1]);
+    // ASSERT_EQ(3, obj.u2_le4.elements[2]);
+    // ASSERT_EQ(3, obj.u2_le4.count);
+    // ASSERT_EQ(1, obj.delimited_fix_le2.count);
+    // ASSERT_EQ(0x0034, obj.u16_2[0]);                            // <-- IMPLICIT ZERO EXTENSION STARTS HERE
+    // ASSERT_EQ(0x0000, obj.u16_2[1]);                            // IT'S
+    // ASSERT_EQ(0, obj.aligned_bitpacked_3_bitpacked_[0]);        //      ZEROS
+    // ASSERT_EQ(0, obj.unaligned_bitpacked_lt3.count);            //          ALL
+    // ASSERT_EQ(0, obj.delimited_var_2[0]._tag_);                 //              THE
+    // ASSERT_NEAR(0, obj.delimited_var_2[0].f16, 1e-9);      //                  WAY
+    // ASSERT_EQ(0, obj.delimited_var_2[1]._tag_);                 //                      DOWN
+    // ASSERT_NEAR(0, obj.delimited_var_2[1].f16, 1e-9);
+    // ASSERT_EQ(0, obj.aligned_bitpacked_le3.count);
+}
+
+
+
+TEST(Serialization, Primitive)
+{
+    using namespace nunavut::testing;
+    for (uint32_t i = 0U; i < 10; i++)
+    {
+        regulated::basics::Primitive_0_1 ref{};
+        ref.a_u64  = randU64();
+        ref.a_u32  = randU32();
+        ref.a_u16  = randU16();
+        ref.a_u8   = randU8();
+        ref.a_u7   = randU8() & 127U;
+        ref.n_u64  = randU64();
+        ref.n_u32  = randU32();
+        ref.n_u16  = randU16();
+        ref.n_u8   = randU8();
+        ref.n_u7   = randU8() & 127U;
+        ref.a_i64  = randI64();
+        ref.a_i32  = randI32();
+        ref.a_i16  = randI16();
+        ref.a_i8   = randI8();
+        ref.a_i7   = randI8() % 64;
+        ref.n_i64  = randI64();
+        ref.n_i32  = randI32();
+        ref.n_i16  = randI16();
+        ref.n_i8   = randI8();
+        ref.n_i7   = randI8() % 64;
+        ref.a_f64  = randF64();
+        ref.a_f32  = randF32();
+        ref.a_f16  = randF16();
+        ref.a_bool = randI8() % 2 == 0;
+        ref.n_bool = randI8() % 2 == 0;
+        ref.n_f64  = randF64();
+        ref.n_f32  = randF32();
+        ref.n_f16  = randF16();
+
+        uint8_t buf[regulated::basics::Primitive_0_1::SERIALIZATION_BUFFER_SIZE_BYTES];
+        std::memset(buf, 0, sizeof(buf));
+        auto result = ref.serialize({{buf, sizeof(buf)}});
+        ASSERT_TRUE(result) << "Error is " << result.error();
+        ASSERT_EQ(
+            static_cast<size_t>(regulated::basics::Primitive_0_1::SERIALIZATION_BUFFER_SIZE_BYTES), result.value());
+
+        regulated::basics::Primitive_0_1 obj;
+        result = obj.deserialize({ {buf, sizeof(buf)} });
+        ASSERT_TRUE(result);
+        EXPECT_EQ(
+            static_cast<size_t>(regulated::basics::Primitive_0_1::SERIALIZATION_BUFFER_SIZE_BYTES), result.value());
+        EXPECT_EQ(hex(ref.a_u64)   , hex(obj.a_u64) );
+        EXPECT_EQ(hex(ref.a_u32)   , hex(obj.a_u32) );
+        EXPECT_EQ(hex(ref.a_u16)   , hex(obj.a_u16) );
+        EXPECT_EQ(hex(ref.a_u8)    , hex(obj.a_u8)  );
+        EXPECT_EQ(hex(ref.a_u7)    , hex(obj.a_u7)  );
+        EXPECT_EQ(hex(ref.n_u64)   , hex(obj.n_u64) );
+        EXPECT_EQ(hex(ref.n_u32)   , hex(obj.n_u32) );
+        EXPECT_EQ(hex(ref.n_u16)   , hex(obj.n_u16) );
+        EXPECT_EQ(hex(ref.n_u8)    , hex(obj.n_u8)  );
+        EXPECT_EQ(hex(ref.n_u7)    , hex(obj.n_u7)  );
+        EXPECT_EQ(hex(ref.a_i64)   , hex(obj.a_i64) );
+        EXPECT_EQ(hex(ref.a_i32)   , hex(obj.a_i32) );
+        EXPECT_EQ(hex(ref.a_i16)   , hex(obj.a_i16) );
+        EXPECT_EQ(hex(ref.a_i8)    , hex(obj.a_i8)  );
+        EXPECT_EQ(hex(ref.a_i7)    , hex(obj.a_i7)  );
+        EXPECT_EQ(hex(ref.n_i64)   , hex(obj.n_i64) );
+        EXPECT_EQ(hex(ref.n_i32)   , hex(obj.n_i32) );
+        EXPECT_EQ(hex(ref.n_i16)   , hex(obj.n_i16) );
+        EXPECT_EQ(hex(ref.n_i8)    , hex(obj.n_i8)  );
+        EXPECT_EQ(hex(ref.n_i7)    , hex(obj.n_i7)  );
+        EXPECT_DOUBLE_EQ(ref.a_f64 , obj.a_f64 );
+        EXPECT_FLOAT_EQ(ref.a_f32  , obj.a_f32 );
+        EXPECT_FLOAT_EQ(ref.a_f16  , obj.a_f16 );
+        EXPECT_EQ(ref.a_bool       , obj.a_bool);
+        EXPECT_EQ(ref.n_bool       , obj.n_bool);
+        EXPECT_DOUBLE_EQ(ref.n_f64 , obj.n_f64 );
+        EXPECT_FLOAT_EQ(ref.n_f32  , obj.n_f32 );
+        EXPECT_FLOAT_EQ(ref.n_f16  , obj.n_f16 );
+    }
+}


### PR DESCRIPTION
This PR is my attempt to create a working modern-looking (de)serialization layer for UAVCAN v1. This work is aimed at #91 progress.

Steps:
* [X] Update googletest to a new version as my installation of Arch Linux is already on a newer compiler (GCC 11), which generates a new warning, which crashes build with `-Werror`.
* [x] Translate C support library to C++
    * [X] Basic bit patterns
    * [X] Bits and integers (de)serialization
    * [x] Floats (de)serialization
* [x] Translate serialization to C++ (with tests!)
    * [x] Primitive types
    * [x] Composite types
    * [x] Const arrays
    * [x] Variable arrays
    * [x] Unions
* [x] Translate deserialization to C++ (with tests!)
    * [X] Primitive types
    * [x] Composite types
    * [x] Const arrays
    * [x] Variable arrays
    * [x] Unions
* [x] Polyfill `std::span` with `NUNAVUT_ASSERT`s to minimize needed code.
* [x] Decide on how to polyfill `std::expected`.
* [X] Remove debug-only headers.
* [ ] Add optimizations
    * [ ] Use VLA implementation with allocators and sizes.
    * [ ] Implement a packed bit array
    * [ ] Various optimizations on zero-cost conversion of types.
* [ ] Make copy-pasted tests more maintainable (using C implementation as `golden`).