### PR TITLE
Fixed windows paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Partial example: generating a C struct
         *
         * Auto-generated, do not edit.
         *
-        * Source file: {{T.source_file_path}}
+        * Source file: {{T.source_file_path | replace("\\", "\\\\")}}
         */
 
         #ifndef {{T.full_name | ln.c.macrofy}}

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -397,7 +397,7 @@ given a template ``common_header.j2``::
     *
     * Auto-generated, do not edit.
     *
-    * Source file: {{T.source_file_path}}
+    * Source file: {{T.source_file_path | replace("\\", "\\\\")}}
     * Generated at: {{now_utc}}
     * Template: {{ self._TemplateReference__context.name }}
     * deprecated: {{T.deprecated}}

--- a/src/nunavut/lang/c/templates/base.j2
+++ b/src/nunavut/lang/c/templates/base.j2
@@ -16,7 +16,7 @@
 // are named with an underscore at the end, like foo_bar_().
 //
 // Generator:     nunavut-{{ nunavut.version }} (serialization was {{ 'not ' * nunavut.support.omit }}enabled)
-// Source file:   {{ T.source_file_path }}
+// Source file:   {{ T.source_file_path | replace("\\", "\\\\") }}
 // Generated at:  {{ now_utc }} UTC
 // Is deprecated: {{ T.deprecated and 'yes' or 'no' }}
 // Fixed port-ID: {{ T.fixed_port_id }}
@@ -54,7 +54,7 @@
 {% endfor %}
 {% for key, value in options.items() -%}
 static_assert( {{ "NUNAVUT_SUPPORT_LANGUAGE_OPTION_{}".format(key) | ln.c.macrofy }} == {{ value | to_static_assertion_value }},
-              "{{ T.source_file_path }} is trying to use a serialization library that was compiled with "
+              "{{ T.source_file_path | replace("\\", "\\\\") }} is trying to use a serialization library that was compiled with "
               "different language options. This is dangerous and therefore not allowed." );
 {% endfor %}
 #ifdef __cplusplus

--- a/src/nunavut/lang/cpp/templates/base.j2
+++ b/src/nunavut/lang/cpp/templates/base.j2
@@ -11,7 +11,7 @@
 // build invocation. TODO: add --reproducible option to prevent any volatile metadata from being generated.
 //
 // Generator:     nunavut-{{ nunavut.version }} (serialization was {{ 'not ' * nunavut.support.omit }}enabled)
-// Source file:   {{ T.source_file_path }}
+// Source file:   {{ T.source_file_path | replace("\\", "\\\\") }}
 // Generated at:  {{ now_utc }} UTC
 // Is deprecated: {{ T.deprecated and 'yes' or 'no' }}
 // Fixed port-ID: {{ T.fixed_port_id }}
@@ -73,7 +73,7 @@
 // +-------------------------------------------------------------------------------------------------------------------+
 {% endif -%}
 static_assert( nunavut::support::options::{{ key | id }} == {{ value | ln.c.to_static_assertion_value }},
-              "{{ T.source_file_path }} "
+              "{{ T.source_file_path | replace("\\", "\\\\") }} "
               "is trying to use a serialization library that was compiled with "
               "different language options. This is dangerous and therefore not "
               "allowed." );

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -7,7 +7,7 @@
 .. autodata:: __version__
 """
 
-__version__ = "1.6.2"  #: The version number used in the release of nunavut to pypi.
+__version__ = "1.6.3"  #: The version number used in the release of nunavut to pypi.
 
 
 __license__ = "MIT"

--- a/test/gentest_json/templates/StructureType.j2
+++ b/test/gentest_json/templates/StructureType.j2
@@ -7,7 +7,7 @@
       {
         "name": "{{ T.short_name }}",
         "type": "{{ T | typename }}",
-        "source" : "{{ T.source_file_path }}",
+        "source" : "{{ T.source_file_path | replace("\\", "\\\\") }}",
         "fixed_port_id": {{ T.fixed_port_id }},
         "deprecated": {{ T.deprecated | ln.js.to_true_or_false }},
         "version":


### PR DESCRIPTION
Fix windows paths that break building on windows, most notably because of static asserts. Backslashes were not properly escaped. In the abscence of a better fix, this replaces backslashes with double backslash in jinja templates, as backslashes should not be used on linux anyway. 