### PR TITLE
Update googletest to a vesrion compatible with GCC11

### DIFF
--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -7,7 +7,7 @@
 .. autodata:: __version__
 """
 
-__version__ = "1.7.2"  #: The version number used in the release of nunavut to pypi.
+__version__ = "1.7.3"  #: The version number used in the release of nunavut to pypi.
 
 
 __license__ = "MIT"


### PR DESCRIPTION
This is a separate patch to update googletest.